### PR TITLE
Specify Rust 2018 edition

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -2,5 +2,6 @@
 name = "transact"
 version = "0.1.0"
 authors = ["Bitwise IO, Inc."]
+edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
This won't affect existing code, but will let us add dependencies going forward without a lot of `extern crate` declarations.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>