### PR TITLE
Remove additional Log dependency from Manifest

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies]
 hex = "0.3"
-log = "0.4"
 protobuf = "2"
 sha2 = "0.8"
 lmdb-zero = ">=0.4.1"


### PR DESCRIPTION
Additional log dependency in the Cargo Manifest was causing the build to fail, this removes one of those duplicates.

Signed-off-by: Shannyn Telander <telander@bitwise.io>