### PR TITLE
Execution registry

### DIFF
--- a/libtransact/src/execution/adapter/mod.rs
+++ b/libtransact/src/execution/adapter/mod.rs
@@ -25,6 +25,7 @@ pub mod test_adapter;
 pub use crate::execution::adapter::error::ExecutionAdapterError;
 
 use crate::context::ContextId;
+use crate::execution::TransactionFamily;
 use crate::transaction::TransactionPair;
 
 pub type OnDoneCallback = FnMut(Result<ExecutionResult, ExecutionAdapterError>);
@@ -56,28 +57,6 @@ pub trait ExecutionAdapter: Send {
 
     /// Stop the internal threads and the Executor will no longer call execute.
     fn stop(self: Box<Self>) -> bool;
-}
-
-#[derive(Eq, PartialEq, Debug, Hash, Clone)]
-pub struct TransactionFamily {
-    family_name: String,
-    family_version: String,
-}
-
-impl TransactionFamily {
-    pub fn new(family_name: String, family_version: String) -> Self {
-        TransactionFamily {
-            family_name,
-            family_version,
-        }
-    }
-
-    pub fn from_pair(transaction_pair: &TransactionPair) -> Self {
-        Self::new(
-            transaction_pair.header().family_name().to_string(),
-            transaction_pair.header().family_version().to_string(),
-        )
-    }
 }
 
 /// An `InvalidTransaction` has information about why the transaction failed.

--- a/libtransact/src/execution/adapter/mod.rs
+++ b/libtransact/src/execution/adapter/mod.rs
@@ -28,8 +28,6 @@ use crate::context::ContextId;
 use crate::execution::ExecutionRegistry;
 use crate::transaction::TransactionPair;
 
-pub type OnDoneCallback = FnMut(Result<ExecutionResult, ExecutionAdapterError>);
-
 /// Implementers of this trait proxy the transaction to the correct component to execute
 /// the transaction.
 pub trait ExecutionAdapter: Send {
@@ -44,7 +42,7 @@ pub trait ExecutionAdapter: Send {
         &self,
         transaction_pair: TransactionPair,
         context_id: ContextId,
-        on_done: Box<OnDoneCallback>,
+        on_done: Box<dyn Fn(Result<ExecutionResult, ExecutionAdapterError>)>,
     );
 
     /// Stop the internal threads and the Executor will no longer call execute.

--- a/libtransact/src/execution/adapter/mod.rs
+++ b/libtransact/src/execution/adapter/mod.rs
@@ -25,23 +25,15 @@ pub mod test_adapter;
 pub use crate::execution::adapter::error::ExecutionAdapterError;
 
 use crate::context::ContextId;
-use crate::execution::TransactionFamily;
+use crate::execution::ExecutionRegistry;
 use crate::transaction::TransactionPair;
 
 pub type OnDoneCallback = FnMut(Result<ExecutionResult, ExecutionAdapterError>);
-pub type OnRegisterCallback = FnMut(TransactionFamily) + Send;
-pub type OnUnregisterCallback = FnMut(TransactionFamily) + Send;
 
 /// Implementers of this trait proxy the transaction to the correct component to execute
 /// the transaction.
 pub trait ExecutionAdapter: Send {
-    /// Register a callback to be fired when the execution adapter registers a new
-    /// capability.
-    fn on_register(&self, callback: Box<OnRegisterCallback>);
-
-    /// Register a callback to be fired when the execution adapter unregisters a
-    /// new capability.
-    fn on_unregister(&self, callback: Box<OnUnregisterCallback>);
+    fn start(&mut self, execution_registry: Box<dyn ExecutionRegistry>);
 
     /// Execute the transaction and provide an callback that handles the result.
     ///

--- a/libtransact/src/execution/adapter/mod.rs
+++ b/libtransact/src/execution/adapter/mod.rs
@@ -18,7 +18,7 @@
 //! Contains execution adapter components and interfaces that proxy the `Transaction`
 //! and its associated state.
 
-pub mod error;
+mod error;
 #[cfg(test)]
 pub mod test_adapter;
 

--- a/libtransact/src/execution/executer_internal.rs
+++ b/libtransact/src/execution/executer_internal.rs
@@ -25,7 +25,7 @@
 //                                                                                                --------- ExecutionAdapter
 //
 
-use crate::execution::adapter::TransactionFamily;
+use crate::execution::TransactionFamily;
 use crate::execution::adapter::{ExecutionAdapter, ExecutionAdapterError, ExecutionResult};
 use crate::scheduler::ExecutionTask;
 use log::warn;

--- a/libtransact/src/execution/executer_internal.rs
+++ b/libtransact/src/execution/executer_internal.rs
@@ -25,8 +25,8 @@
 //                                                                                                --------- ExecutionAdapter
 //
 
-use crate::execution::TransactionFamily;
 use crate::execution::adapter::{ExecutionAdapter, ExecutionAdapterError, ExecutionResult};
+use crate::execution::{ExecutionRegistry, TransactionFamily};
 use crate::scheduler::ExecutionTask;
 use log::warn;
 use std::collections::{HashMap, HashSet};
@@ -170,26 +170,22 @@ impl ExecuterThread {
 
     pub fn start(&mut self) -> Result<(), ExecuterThreadError> {
         if self.sender.is_none() {
-            let (registration_sender, receiver) = channel();
+            let (registry_sender, receiver) = channel();
 
-            for (index, execution_adapter) in self.execution_adapters.drain(0..).enumerate() {
+            for (index, mut execution_adapter) in self.execution_adapters.drain(0..).enumerate() {
                 let (sender, adapter_receiver) = channel();
                 let ee_sender = NamedExecutionEventSender::new(sender, index);
-                Self::add_register_callback(
-                    execution_adapter.as_ref(),
-                    ee_sender.clone(),
-                    registration_sender.clone(),
-                );
-                Self::add_unregister_callback(
-                    execution_adapter.as_ref(),
-                    ee_sender,
-                    registration_sender.clone(),
-                );
+
+                execution_adapter.start(Box::new(InternalRegistry {
+                    event_sender: ee_sender,
+                    registry_sender: registry_sender.clone(),
+                }));
+
                 match Self::start_execution_adapter_thread(
                     Arc::clone(&self.stop),
                     execution_adapter,
                     adapter_receiver,
-                    &registration_sender,
+                    &registry_sender,
                     index,
                 ) {
                     Ok(join_handle) => {
@@ -202,7 +198,7 @@ impl ExecuterThread {
                 }
             }
 
-            self.sender = Some(registration_sender);
+            self.sender = Some(registry_sender);
             match self.start_thread(receiver) {
                 Ok(join_handle) => {
                     self.internal_thread = Some(join_handle);
@@ -428,48 +424,6 @@ impl ExecuterThread {
         if let Some(p) = p {
             parked.insert(transaction_family, p);
         }
-    }
-
-    fn add_register_callback(
-        execution_adapter: &ExecutionAdapter,
-        sender: NamedExecutionEventSender,
-        register_sender: RegistrationExecutionEventSender,
-    ) {
-        let callback: Box<FnMut(TransactionFamily) + Send> =
-            Box::new(move |transaction_family: TransactionFamily| {
-                if let Err(err) =
-                    register_sender.send(RegistrationExecutionEvent::RegistrationChange(
-                        RegistrationChange::RegisterRequest((transaction_family, sender.clone())),
-                    ))
-                {
-                    warn!(
-                        "During sending registration of transaction family on channel: {}",
-                        err
-                    );
-                }
-            });
-        execution_adapter.on_register(callback);
-    }
-
-    fn add_unregister_callback(
-        execution_adapter: &ExecutionAdapter,
-        sender: NamedExecutionEventSender,
-        unregister_sender: RegistrationExecutionEventSender,
-    ) {
-        let callback: Box<FnMut(TransactionFamily) + Send> =
-            Box::new(move |transaction_family: TransactionFamily| {
-                if let Err(err) =
-                    unregister_sender.send(RegistrationExecutionEvent::RegistrationChange(
-                        RegistrationChange::UnregisterRequest((transaction_family, sender.clone())),
-                    ))
-                {
-                    warn!(
-                        "During sending unregistration of transaction family on channel: {}",
-                        err
-                    );
-                }
-            });
-        execution_adapter.on_unregister(callback);
     }
 }
 
@@ -730,5 +684,40 @@ mod tests {
         (0..NUMBER_OF_TRANSACTIONS)
             .map(move |_| create_txn(&signer))
             .map(move |txn_pair| ExecutionTask::new(txn_pair, context_id.clone()))
+    }
+}
+
+struct InternalRegistry {
+    registry_sender: RegistrationExecutionEventSender,
+    event_sender: NamedExecutionEventSender,
+}
+
+impl ExecutionRegistry for InternalRegistry {
+    fn register_transaction_family(&mut self, family: TransactionFamily) {
+        if let Err(err) = self
+            .registry_sender
+            .send(RegistrationExecutionEvent::RegistrationChange(
+                RegistrationChange::RegisterRequest((family, self.event_sender.clone())),
+            ))
+        {
+            warn!(
+                "During sending registration of transaction family on channel: {}",
+                err
+            );
+        }
+    }
+
+    fn unregister_transaction_family(&mut self, family: &TransactionFamily) {
+        if let Err(err) = self
+            .registry_sender
+            .send(RegistrationExecutionEvent::RegistrationChange(
+                RegistrationChange::UnregisterRequest((family.clone(), self.event_sender.clone())),
+            ))
+        {
+            warn!(
+                "During sending unregistration of transaction family on channel: {}",
+                err
+            );
+        }
     }
 }

--- a/libtransact/src/execution/executer_internal.rs
+++ b/libtransact/src/execution/executer_internal.rs
@@ -244,11 +244,12 @@ impl ExecuterThread {
                             let (pair, context_id) = task.take();
 
                             let callback = Box::new(move |result| {
+                                // Without this line, the function is considered a FnOnce, instead
+                                // of an Fn.  This seems to be a strange quirk of the compiler
                                 let res_sender = results_sender.clone();
                                 match result {
                                     Ok(tp_processing_result) => {
-                                        if let Err(err) = results_sender.send(tp_processing_result)
-                                        {
+                                        if let Err(err) = res_sender.send(tp_processing_result) {
                                             warn!(
                                             "Sending TransactionProcessingResult on channel: {}",
                                             err

--- a/libtransact/src/execution/mod.rs
+++ b/libtransact/src/execution/mod.rs
@@ -20,4 +20,4 @@
 
 pub mod adapter;
 pub mod executer;
-pub mod executer_internal;
+mod executer_internal;

--- a/libtransact/src/execution/mod.rs
+++ b/libtransact/src/execution/mod.rs
@@ -56,3 +56,17 @@ impl TransactionFamily {
         &self.family_version
     }
 }
+
+/// The registry of transaction families
+pub trait ExecutionRegistry: Send {
+    /// Register the given transaction family.
+    ///
+    /// Adding a family to the registry indicates that the family can be processed by an
+    /// ExecutionAdapter.
+    fn register_transaction_family(&mut self, family: TransactionFamily);
+
+    /// Unregister the given transaction family.
+    ///
+    /// Signals that a transaction family can no longer be processed by an ExecutionAdapter.
+    fn unregister_transaction_family(&mut self, family: &TransactionFamily);
+}

--- a/libtransact/src/execution/mod.rs
+++ b/libtransact/src/execution/mod.rs
@@ -21,3 +21,38 @@
 pub mod adapter;
 pub mod executer;
 mod executer_internal;
+
+use crate::transaction::TransactionPair;
+
+/// A Transaction Family Descriptor
+#[derive(Eq, PartialEq, Debug, Hash, Clone)]
+pub struct TransactionFamily {
+    family_name: String,
+    family_version: String,
+}
+
+impl TransactionFamily {
+    /// Constructs a new Transaction Family Descriptor.
+    pub fn new(family_name: String, family_version: String) -> Self {
+        TransactionFamily {
+            family_name,
+            family_version,
+        }
+    }
+
+    /// Creates a Transaction Family Descriptor using the information in a TransactionPair.
+    pub fn from_pair(transaction_pair: &TransactionPair) -> Self {
+        Self::new(
+            transaction_pair.header().family_name().to_string(),
+            transaction_pair.header().family_version().to_string(),
+        )
+    }
+
+    pub fn family_name(&self) -> &str {
+        &self.family_name
+    }
+
+    pub fn family_version(&self) -> &str {
+        &self.family_version
+    }
+}


### PR DESCRIPTION
Replace the callbacks with a trait called `ExecutionRegistry` (for the time being - if we add more methods, it will have to be renamed).

Additionally,

    * Removes some internals from the public library API
    * Removes the OnDoneCallback type alias, to allow the use of the `dyn` keyword.

Replacement for #33 