### PR TITLE
Remove unused 'use std;' from signing module

### DIFF
--- a/libtransact/src/signing/mod.rs
+++ b/libtransact/src/signing/mod.rs
@@ -1,8 +1,6 @@
 pub mod error;
 pub mod hash;
 
-use std;
-
 pub use crate::signing::error::Error;
 
 pub trait Signer {


### PR DESCRIPTION
This removes a compiler warning.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>