### PR TITLE
Remove unused Successor impl

### DIFF
--- a/libtransact/src/state/change_log.rs
+++ b/libtransact/src/state/change_log.rs
@@ -47,16 +47,6 @@ impl FromNative<Successor> for merkle::ChangeLogEntry_Successor {
     }
 }
 
-impl Successor {
-    fn to_bytes(&self) -> Result<Vec<u8>, StateDatabaseError> {
-        Ok(self.clone().into_proto()?.write_to_bytes()?)
-    }
-
-    fn from_bytes(bytes: &[u8]) -> Result<Successor, StateDatabaseError> {
-        Ok(Successor::from_proto(protobuf::parse_from_bytes(bytes)?)?)
-    }
-}
-
 impl IntoProto<merkle::ChangeLogEntry_Successor> for Successor {}
 impl IntoNative<Successor> for merkle::ChangeLogEntry_Successor {}
 


### PR DESCRIPTION
The Successor impl had implementations for to_bytes/from_bytes, which
were not used and were not public functions. This was the only things
implemented on Successor, so removed the entire impl block.

This fixes a couple compiler warnings.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>