### PR TITLE
Remove unnecessary extern crate statements

### DIFF
--- a/libtransact/src/lib.rs
+++ b/libtransact/src/lib.rs
@@ -31,10 +31,3 @@ pub mod transaction;
 
 #[macro_use]
 extern crate log;
-extern crate cbor;
-extern crate hex;
-extern crate libc;
-extern crate lmdb_zero;
-
-#[cfg(test)]
-extern crate rand;


### PR DESCRIPTION
These were necessarily with an older version of Rust, but are no longer
needed in current stable Rust (1.32.0).

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>