### PR TITLE
Add initial Context Manager

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -14,6 +14,7 @@ log = { version = "0.4", features = ["std"] }
 cbor-codec = "0.7"
 libc = ">=0.2.35"
 openssl = "0.10"
+uuid = { version = "0.7", features = ["v4"] }
 
 [dev-dependencies]
 sawtooth-sdk = "0.1"

--- a/libtransact/src/context/manager.rs
+++ b/libtransact/src/context/manager.rs
@@ -1,0 +1,541 @@
+/*
+ * Copyright 2019 Bitwise IO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::error::Error as StdError;
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::str;
+
+use crate::context::{Context, ContextId};
+use crate::receipts::{
+    Event, StateChange, TransactionReceipt, TransactionReceiptBuilder,
+    TransactionReceiptBuilderError,
+};
+use crate::state::error::StateReadError;
+use crate::state::Read;
+
+#[derive(Debug)]
+pub enum ContextManagerError {
+    MissingContextError(String),
+    TransactionReceiptBuilderError(TransactionReceiptBuilderError),
+    StateReadError(StateReadError),
+}
+
+impl StdError for ContextManagerError {
+    fn description(&self) -> &str {
+        match *self {
+            ContextManagerError::MissingContextError(ref msg) => msg,
+            ContextManagerError::TransactionReceiptBuilderError(ref err) => err.description(),
+            ContextManagerError::StateReadError(ref err) => err.description(),
+        }
+    }
+}
+
+impl std::fmt::Display for ContextManagerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            ContextManagerError::MissingContextError(ref s) => {
+                write!(f, "Unable to find specified Context: {:?}", s)
+            }
+            ContextManagerError::TransactionReceiptBuilderError(ref err) => {
+                write!(f, "A TransactionReceiptBuilder error occured: {}", err)
+            }
+            ContextManagerError::StateReadError(ref err) => {
+                write!(f, "A State Read error occured: {}", err)
+            }
+        }
+    }
+}
+
+impl From<TransactionReceiptBuilderError> for ContextManagerError {
+    fn from(err: TransactionReceiptBuilderError) -> Self {
+        ContextManagerError::TransactionReceiptBuilderError(err)
+    }
+}
+
+impl From<StateReadError> for ContextManagerError {
+    fn from(err: StateReadError) -> Self {
+        ContextManagerError::StateReadError(err)
+    }
+}
+
+pub struct ContextManager<K, V, R: Read<StateId = String, Key = K, Value = V>> {
+    contexts: HashMap<ContextId, Context<K, V>>,
+    database: R,
+}
+impl<
+        K: Hash + Eq + Clone + Debug + Default,
+        V: Clone + Debug + Default,
+        R: Read<StateId = String, Key = K, Value = V>,
+    > ContextManager<K, V, R>
+{
+    pub fn new(database: R) -> Self {
+        ContextManager {
+            contexts: HashMap::new(),
+            database,
+        }
+    }
+
+    /// Returns a mutable Context within the ContextManager's Context list specified by the ContextId
+    fn get_context_mut(
+        &mut self,
+        context_id: &ContextId,
+    ) -> Result<&mut Context<K, V>, ContextManagerError> {
+        self.contexts.get_mut(context_id).ok_or_else(|| {
+            ContextManagerError::MissingContextError(
+                str::from_utf8(context_id)
+                    .expect("Unable to generate string from ContextId")
+                    .to_string(),
+            )
+        })
+    }
+
+    /// Returns a Context within the ContextManager's Context list specified by the ContextId
+    fn get_context(&self, context_id: &ContextId) -> Result<&Context<K, V>, ContextManagerError> {
+        self.contexts.get(context_id).ok_or_else(|| {
+            ContextManagerError::MissingContextError(
+                str::from_utf8(context_id)
+                    .expect("Unable to generate string from ContextId")
+                    .to_string(),
+            )
+        })
+    }
+
+    /// Get the values associated with list of keys, from a specific Context.
+    /// If a key is not found in the context, State is then checked for these keys.
+    pub fn get(
+        &self,
+        context_id: &ContextId,
+        keys: &[K],
+    ) -> Result<Vec<(K, Option<V>)>, ContextManagerError> {
+        let mut key_values = Vec::new();
+        for key in keys.iter().rev() {
+            let mut context = self.get_context(context_id)?;
+            let mut contexts = VecDeque::new();
+            for context_id in context.base_contexts().iter() {
+                contexts.push_back(self.get_context(context_id)?);
+            }
+            if !context.contains(&key) && !contexts.is_empty() {
+                while let Some(current_context) = contexts.pop_front() {
+                    if current_context.contains(&key) {
+                        context = current_context;
+                        break;
+                    } else {
+                        context = current_context;
+                        for context_id in context.base_contexts().iter() {
+                            contexts.push_back(self.get_context(context_id)?);
+                        }
+                    }
+                }
+            }
+            if context.contains(&key) {
+                match context
+                    .state_changes()
+                    .iter()
+                    .rev()
+                    .find(|state_change| state_change.has_key(&key))
+                {
+                    Some(StateChange::Set { key: k, value: v }) => {
+                        key_values.push((k.clone(), Some(v.clone())))
+                    }
+                    _ => {
+                        key_values.push((key.clone(), None));
+                    }
+                }
+            } else if let Some(v) = self
+                .database
+                .get(context.state_id(), &[key.clone()])?
+                .get(&key)
+            {
+                key_values.push((key.clone(), Some(v.clone())))
+            }
+        }
+        Ok(key_values)
+    }
+
+    /// Adds a StateChange::Set to the specified Context
+    pub fn set_state(
+        &mut self,
+        context_id: &ContextId,
+        key: K,
+        value: V,
+    ) -> Result<(), ContextManagerError> {
+        let context = self.get_context_mut(context_id)?;
+        context.set_state(key, value);
+        Ok(())
+    }
+
+    /// Adds a StateChange::Delete to the specified Context, returning the value, if found, that is
+    /// associated with the specified key.
+    pub fn delete_state(
+        &mut self,
+        context_id: &ContextId,
+        key: K,
+    ) -> Result<Option<V>, ContextManagerError> {
+        // Adding a StateChange::Delete to the specified Context, which will occur no matter which
+        // Context or State the key and associated value is found in.
+        let context_value = self.get_context_mut(context_id)?.delete_state(key.clone());
+        if let Some(value) = context_value {
+            return Ok(Some(value));
+        }
+
+        let current_context = self.get_context(context_id)?;
+        let mut containing_context = self.get_context(context_id)?;
+
+        let mut contexts = VecDeque::new();
+        contexts.push_front(containing_context);
+        // Adding dependent Contexts to search for the Key
+        for context_id in containing_context.base_contexts().iter() {
+            contexts.push_back(self.get_context(context_id)?);
+        }
+
+        while let Some(context) = contexts.pop_front() {
+            if context.contains(&key) {
+                containing_context = context;
+                break;
+            } else {
+                for context_id in context.base_contexts().iter() {
+                    contexts.push_back(self.get_context(context_id)?);
+                }
+            }
+        }
+        if containing_context.contains(&key) {
+            if let Some(v) = containing_context.get_state(&key) {
+                return Ok(Some(v.clone()));
+            }
+        } else if let Some(value) = self
+            .database
+            .get(current_context.state_id(), &[key.clone()])?
+            .get(&key)
+        {
+            return Ok(Some(value.clone()));
+        }
+        Ok(None)
+    }
+
+    /// Adds an Event to the specified Context.
+    pub fn add_event(
+        &mut self,
+        context_id: &ContextId,
+        event: Event,
+    ) -> Result<(), ContextManagerError> {
+        let context = self.get_context_mut(&context_id)?;
+        context.add_event(event);
+        Ok(())
+    }
+
+    /// Adds Data to the specified Context.
+    pub fn add_data(
+        &mut self,
+        context_id: &ContextId,
+        data: Vec<u8>,
+    ) -> Result<(), ContextManagerError> {
+        let context = self.get_context_mut(&context_id)?;
+        context.add_data(data);
+        Ok(())
+    }
+
+    /// Creates a Context, and returns the resulting ContextId.
+    pub fn create_context(
+        &mut self,
+        dependent_contexts: Vec<ContextId>,
+        state_id: &str,
+    ) -> ContextId {
+        let new_context = Context::new(state_id, dependent_contexts);
+        self.contexts.insert(*new_context.id(), new_context.clone());
+        *new_context.id()
+    }
+
+    /// Creates a TransactionReceipt based on the information available within the specified Context.
+    pub fn get_transaction_receipt(
+        &self,
+        context_id: &ContextId,
+        transaction_id: &str,
+    ) -> Result<TransactionReceipt<K, V>, ContextManagerError> {
+        let context = self.get_context(context_id)?;
+        let new_transaction_receipt = TransactionReceiptBuilder::new()
+            .with_state_changes(context.state_changes().to_vec())
+            .with_events(context.events().to_vec())
+            .with_data(context.data().to_vec())
+            .with_transaction_id(transaction_id.to_string())
+            .build()?;
+        Ok(new_transaction_receipt)
+    }
+
+    pub fn drop_context(&self, _context_id: ContextId) {
+        unimplemented!();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    use crate::receipts::EventBuilder;
+    use crate::state;
+    use crate::state::hashmap::HashMapState;
+    use crate::state::Write;
+
+    static KEY1: &str = "111111111111111111111111111111111111111111111111111111111111111111";
+    static KEY2: &str = "222222222222222222222222222222222222222222222222222222222222222222";
+    static KEY3: &str = "333333333333333333333333333333333333333333333333333333333333333333";
+    static KEY4: &str = "444444444444444444444444444444444444444444444444444444444444444444";
+    static KEY5: &str = "555555555555555555555555555555555555555555555555555555555555555555";
+    static VALUE1: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    static VALUE2: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    static VALUE3: &str = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+    static VALUE4: &str = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+
+    static BYTES1: [u8; 4] = [0x01, 0x02, 0x03, 0x04];
+    static BYTES2: [u8; 4] = [0x05, 0x06, 0x07, 0x08];
+
+    static EVENT_TYPE1: &str = "sawtooth/block-commit";
+    static ATTR1: (&str, &str) = (
+        "block_id",
+        "f40b90d06b4a9074af2ab09e0187223da7466be75ec0f472 \
+         f2edd5f22960d76e402e6c07c90b7816374891d698310dd25d9b88dce7dbcba8219d9f7c9cae1861",
+    );
+    static ATTR2: (&str, &str) = ("block_num", "3");
+
+    fn make_manager(
+        state_changes: Option<Vec<state::StateChange<String, String>>>,
+    ) -> (ContextManager<String, String, HashMapState>, String) {
+        let state = HashMapState::new();
+        let mut state_id = HashMapState::state_id(&HashMap::new());
+        if let Some(changes) = state_changes {
+            state_id = state.commit(&state_id, changes.as_slice()).unwrap();
+        }
+
+        (ContextManager::new(state), state_id)
+    }
+
+    fn check_state_change(state_change: StateChange<String, String>) {
+        match state_change {
+            StateChange::Set { key, value } => {
+                assert_eq!(KEY1, key);
+                assert_eq!(VALUE1, value);
+            }
+            StateChange::Delete { key } => {
+                assert_eq!(KEY1, key);
+            }
+        }
+    }
+
+    fn check_transaction_receipt(
+        transaction_receipt: TransactionReceipt<String, String>,
+        event: Event,
+    ) {
+        for state_change in transaction_receipt.state_changes {
+            check_state_change(state_change)
+        }
+        assert_eq!(vec!(event), transaction_receipt.events);
+        assert_eq!(vec!(BYTES2.to_vec()), transaction_receipt.data);
+    }
+
+    #[test]
+    fn create_contexts() {
+        let (mut manager, state_id) = make_manager(None);
+        let first_context_id = manager.create_context(Vec::new(), &state_id);
+        assert!(!manager.contexts.is_empty());
+        assert!(manager.contexts.get(&first_context_id).is_some());
+
+        let second_context_id = manager.create_context(Vec::new(), &state_id);
+        let second_context = manager.get_context(&second_context_id).unwrap();
+        assert_eq!(&second_context_id, second_context.id());
+        assert_eq!(manager.contexts.len(), 2);
+    }
+
+    #[test]
+    fn add_context_event() {
+        let (mut manager, state_id) = make_manager(None);
+        let context_id = manager.create_context(Vec::new(), &state_id);
+        let event = EventBuilder::new()
+            .with_event_type(EVENT_TYPE1.to_string())
+            .with_attributes(vec![
+                (ATTR1.0.to_string(), ATTR1.1.to_string()),
+                (ATTR2.0.to_string(), ATTR2.1.to_string()),
+            ])
+            .with_data(BYTES1.to_vec())
+            .build()
+            .unwrap();
+        let event_add_result = manager.add_event(&context_id, event.clone());
+        assert!(event_add_result.is_ok());
+        let context = manager.get_context(&context_id).unwrap();
+        assert_eq!(context.events()[0], event.clone());
+    }
+
+    #[test]
+    fn add_context_data() {
+        let (mut manager, state_id) = make_manager(None);
+        let context_id = manager.create_context(Vec::new(), &state_id);
+
+        let data_add_result = manager.add_data(&context_id, BYTES2.to_vec());
+        let context = manager.get_context(&context_id).unwrap();
+        assert!(data_add_result.is_ok());
+        assert_eq!(context.data()[0], BYTES2);
+    }
+
+    #[test]
+    fn create_transaction_receipt() {
+        let (mut manager, state_id) = make_manager(None);
+
+        let context_id = manager.create_context(Vec::new(), &state_id);
+        let mut context = manager.get_context(&context_id).unwrap();
+        assert_eq!(&context_id, context.id());
+
+        let set_result = manager.set_state(&context_id, KEY1.to_string(), VALUE1.to_string());
+        assert!(set_result.is_ok());
+        let delete_result = manager.delete_state(&context_id, KEY1.to_string()).unwrap();
+        assert!(delete_result.is_some());
+
+        // Adding an Event to the Context, to be used to build the TransactionReceipt
+        let event = EventBuilder::new()
+            .with_event_type(EVENT_TYPE1.to_string())
+            .with_attributes(vec![
+                (ATTR1.0.to_string(), ATTR1.1.to_string()),
+                (ATTR2.0.to_string(), ATTR2.1.to_string()),
+            ])
+            .with_data(BYTES1.to_vec())
+            .build()
+            .unwrap();
+        let event_add_result = manager.add_event(&context_id, event.clone());
+        assert!(event_add_result.is_ok());
+        context = manager.get_context(&context_id).unwrap();
+        assert_eq!(context.events()[0], event.clone());
+
+        // Adding Data to the Context, to be used to build the TransactionReceipt
+        let data_add_result = manager.add_data(&context_id, BYTES2.to_vec());
+        context = manager.get_context(&context_id).unwrap();
+        assert!(data_add_result.is_ok());
+        assert_eq!(context.data()[0], BYTES2);
+
+        // Building the TransactionReceipt from the objects within the specified Context
+        let transaction_receipt = manager.get_transaction_receipt(&context_id, KEY2).unwrap();
+        check_transaction_receipt(transaction_receipt, event)
+    }
+
+    #[test]
+    fn add_set_state_change() {
+        let (mut manager, state_id) = make_manager(None);
+
+        let context_id = manager.create_context(Vec::new(), &state_id);
+
+        let set_result = manager.set_state(&context_id, KEY1.to_string(), VALUE1.to_string());
+        assert!(set_result.is_ok());
+
+        let get_value = manager
+            .get_context(&context_id)
+            .unwrap()
+            .get_state(&KEY1.to_string());
+        assert_eq!(get_value, Some(&VALUE1.to_string()));
+    }
+
+    #[test]
+    fn add_delete_state_change() {
+        // Creating a ContextManager with a single Context.
+        let state_changes = vec![state::StateChange::Set {
+            key: KEY1.to_string(),
+            value: VALUE1.to_string(),
+        }];
+        let (mut manager, state_id) = make_manager(Some(state_changes));
+        let ancestor_context = manager.create_context(Vec::new(), &state_id);
+
+        assert!(manager
+            .set_state(&ancestor_context, KEY2.to_string(), VALUE2.to_string())
+            .is_ok());
+
+        let current_context_id = manager.create_context(vec![ancestor_context], &state_id);
+        assert!(manager
+            .set_state(&current_context_id, KEY3.to_string(), VALUE3.to_string())
+            .is_ok());
+        assert!(manager
+            .set_state(&current_context_id, KEY4.to_string(), VALUE4.to_string())
+            .is_ok());
+
+        let deleted_state_value = manager
+            .delete_state(&current_context_id, KEY1.to_string())
+            .unwrap();
+        assert!(deleted_state_value.is_some());
+        assert_eq!(deleted_state_value, Some(VALUE1.to_string()));
+
+        let deleted_ancestor_value = manager
+            .delete_state(&current_context_id, KEY2.to_string())
+            .unwrap();
+        assert!(deleted_ancestor_value.is_some());
+        assert_eq!(deleted_ancestor_value, Some(VALUE2.to_string()));
+
+        let deleted_current_value = manager
+            .delete_state(&current_context_id, KEY3.to_string())
+            .unwrap();
+        assert!(deleted_current_value.is_some());
+        assert_eq!(deleted_current_value, Some(VALUE3.to_string()));
+
+        assert!(manager
+            .delete_state(&current_context_id, KEY5.to_string())
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn get_values() {
+        // Creating a ContextManager with a single Context, with a HashMapState backing it
+        let state_changes = vec![state::StateChange::Set {
+            key: KEY1.to_string(),
+            value: VALUE1.to_string(),
+        }];
+        let (mut manager, state_id) = make_manager(Some(state_changes));
+        let ancestor_context = manager.create_context(Vec::new(), &state_id);
+        let add_result = manager.set_state(&ancestor_context, KEY2.to_string(), VALUE2.to_string());
+        assert!(add_result.is_ok());
+
+        let context_id = manager.create_context(vec![ancestor_context], &state_id);
+
+        // Validates the result from adding the state change to the Context within the ContextManager.
+        assert!(manager
+            .set_state(&context_id, KEY3.to_string(), VALUE3.to_string())
+            .is_ok());
+        assert!(manager
+            .set_state(&context_id, KEY4.to_string(), VALUE4.to_string())
+            .is_ok());
+        assert!(manager
+            .delete_state(&context_id, KEY4.to_string())
+            .unwrap()
+            .is_some());
+
+        // Creating a collection of keys to retrieve the values saved in Context or State.
+        let keys = vec![
+            KEY1.to_string(),
+            KEY2.to_string(),
+            KEY4.to_string(),
+            KEY5.to_string(),
+        ];
+        let mut key_values = manager.get(&context_id, &keys).unwrap();
+        // Two Values are found from the Keys list as KEY4 was deleted and KEY5 does not exist
+        assert_eq!(key_values.len(), 2);
+        assert_eq!(
+            key_values.pop().unwrap(),
+            (KEY1.to_string(), Some(VALUE1.to_string()))
+        );
+        assert_eq!(
+            key_values.pop().unwrap(),
+            (KEY2.to_string(), Some(VALUE2.to_string()))
+        );
+    }
+}

--- a/libtransact/src/context/mod.rs
+++ b/libtransact/src/context/mod.rs
@@ -19,6 +19,8 @@
 /// modify events, data, and state.
 pub type ContextId = [u8; 16];
 
+pub mod manager;
+
 use crate::receipts::Event;
 use std::fmt::Debug;
 use std::mem;

--- a/libtransact/src/context/mod.rs
+++ b/libtransact/src/context/mod.rs
@@ -18,3 +18,226 @@
 /// Unique id that references a "Context" from which a `Transaction` can query state and
 /// modify events, data, and state.
 pub type ContextId = [u8; 16];
+
+use crate::receipts::Event;
+use std::fmt::Debug;
+use std::mem;
+use uuid::Uuid;
+
+use crate::receipts::StateChange;
+
+#[derive(Debug, Clone, Default)]
+pub struct Context<K, V> {
+    base_contexts: Vec<ContextId>,
+    state_changes: Vec<StateChange<K, V>>,
+    id: ContextId,
+    data: Vec<Vec<u8>>,
+    events: Vec<Event>,
+    state_id: String,
+}
+
+impl<K: PartialEq + Clone + Debug, V: Clone + Debug> Context<K, V> {
+    pub fn new(state_id: &str, base_contexts: Vec<ContextId>) -> Self {
+        Context {
+            base_contexts,
+            state_id: state_id.to_string(),
+            state_changes: Vec::new(),
+            id: *Uuid::new_v4().as_bytes(),
+            data: Vec::new(),
+            events: Vec::new(),
+        }
+    }
+
+    pub fn base_contexts(&self) -> &[ContextId] {
+        &self.base_contexts
+    }
+    pub fn events(&self) -> &Vec<Event> {
+        &self.events
+    }
+
+    pub fn state_changes(&self) -> &Vec<StateChange<K, V>> {
+        &self.state_changes
+    }
+
+    pub fn id(&self) -> &ContextId {
+        &self.id
+    }
+
+    pub fn data(&self) -> &Vec<Vec<u8>> {
+        &self.data
+    }
+
+    pub fn state_id(&self) -> &String {
+        &self.state_id
+    }
+
+    pub fn add_event(&mut self, event: Event) {
+        if !self.events().contains(&event) {
+            self.events.push(event);
+        }
+    }
+
+    pub fn add_data(&mut self, data: Vec<u8>) {
+        if !self.data().contains(&data) {
+            self.data.push(data);
+        }
+    }
+
+    pub fn get_state(&self, key: &K) -> Option<&V> {
+        if let Some(StateChange::Set { value: v, .. }) = self
+            .state_changes
+            .iter()
+            .rev()
+            .find(|state_change| state_change.has_key(&key))
+        {
+            return Some(v);
+        }
+        None
+    }
+
+    /// Adds StateChange::Set without deleting previous StateChanges associated with the Key
+    pub fn set_state(&mut self, key: K, value: V) {
+        let new_state_change = StateChange::Set { key, value };
+        self.state_changes.push(new_state_change);
+    }
+
+    /// Adds StateChange::Delete and returns the value associated to the key being deleted
+    pub fn delete_state(&mut self, key: K) -> Option<V> {
+        let found_state_change = self
+            .state_changes
+            .iter_mut()
+            .rev()
+            .find(|state_change| state_change.has_key(&key));
+        if let Some(StateChange::Set { .. }) = found_state_change {
+            // If a StateChange::Set is found associated with the key, the value set is returned.
+            let mut new_state_change: StateChange<_, _> = StateChange::Delete { key };
+            mem::swap(found_state_change.unwrap(), &mut new_state_change);
+            if let StateChange::Set { value: v, .. } = new_state_change {
+                return Some(v);
+            }
+        } else if found_state_change.is_none() {
+            // If no StateChange, Set or Delete, is found associated with the key, a new Delete
+            // is added to the list of StateChanges with the value returned as None.
+            self.state_changes.push(StateChange::Delete { key });
+        }
+        None
+    }
+
+    /// Checks to see if the Key is referenced by any StateChanges within the Context
+    pub fn contains(&self, key: &K) -> bool {
+        for state_change in self.state_changes().iter().rev() {
+            match state_change {
+                StateChange::Set { key: k, .. } => {
+                    if k == key {
+                        return true;
+                    }
+                }
+                StateChange::Delete { key: k } => {
+                    if k == key {
+                        return false;
+                    }
+                }
+            }
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::receipts::StateChange;
+
+    static KEY1: &str = "111111111111111111111111111111111111111111111111111111111111111111";
+    static KEY2: &str = "222222222222222222222222222222222222222222222222222222222222222222";
+    static KEY3: &str = "333333333333333333333333333333333333333333333333333333333333333333";
+    static BYTES1: [u8; 4] = [0x01, 0x02, 0x03, 0x04];
+    static BYTES2: [u8; 4] = [0x05, 0x06, 0x07, 0x08];
+    static BYTES3: [u8; 4] = [0x09, 0x0a, 0x0b, 0x0c];
+
+    #[test]
+    fn get_state() {
+        let first_key = &KEY1.to_string();
+        let first_value = &BYTES1;
+        let base_contexts = Vec::new();
+        let mut context = Context::new(&KEY3, base_contexts);
+        context.set_state(first_key, first_value);
+        assert!(context.contains(&first_key));
+        let state_value = context.get_state(&first_key);
+        assert_eq!(state_value, Some(&first_value));
+    }
+
+    #[test]
+    fn test_compare_state_change() {
+        let first_set: StateChange<String, [u8; 4]> = StateChange::Set {
+            key: KEY1.to_string(),
+            value: BYTES1,
+        };
+        let second_set: StateChange<String, [u8; 4]> = StateChange::Set {
+            key: KEY2.to_string(),
+            value: BYTES2,
+        };
+        let delete_first: StateChange<String, [u8; 4]> = StateChange::Delete {
+            key: KEY1.to_string(),
+        };
+        let delete_second: StateChange<String, [u8; 4]> = StateChange::Delete {
+            key: KEY2.to_string(),
+        };
+        let first_set_key = KEY1.to_string();
+        assert_eq!(first_set.has_key(&first_set_key), true);
+        assert_eq!(second_set.has_key(&first_set_key), false);
+        assert_eq!(delete_first.has_key(&first_set_key), true);
+        assert_eq!(delete_second.has_key(&first_set_key), false);
+    }
+
+    #[test]
+    fn test_contains() {
+        let first_key = &KEY1.to_string();
+        let second_key = &KEY2.to_string();
+
+        let base_contexts = Vec::new();
+        let mut context = Context::new(&KEY3, base_contexts);
+        context.set_state(first_key, &BYTES1);
+        assert!(context.contains(&first_key));
+
+        context.set_state(first_key, &BYTES2);
+        assert!(context.contains(&first_key));
+
+        context.set_state(second_key, &BYTES3);
+        let deleted_value = context.delete_state(&first_key);
+        assert_eq!(deleted_value, Some(&BYTES2));
+
+        assert!(context.contains(&second_key));
+        assert!(!context.contains(&first_key));
+    }
+
+    #[test]
+    fn verify_state_changes() {
+        let first_key = &KEY1.to_string();
+        let second_key = &KEY2.to_string();
+
+        let mut context = Context::new(&KEY3, Vec::new());
+        context.set_state(first_key, &BYTES1);
+        context.set_state(first_key, &BYTES2);
+        context.set_state(second_key, &BYTES3);
+        assert_eq!(context.state_changes().len(), 3);
+
+        let deleted_value = context.delete_state(&first_key);
+        assert_ne!(deleted_value, Some(&BYTES3));
+
+        assert_eq!(context.state_changes().len(), 3);
+        let first_key_set = context
+            .state_changes()
+            .iter()
+            .cloned()
+            .find(|change| change.has_key(&first_key));
+        if let Some(StateChange::Set { key: k, value: v }) = first_key_set {
+            assert_eq!(k, first_key);
+            assert_ne!(Some(v), deleted_value);
+        }
+        if let StateChange::Set { key: k, value: v } = &context.state_changes()[1] {
+            assert_eq!(k, &first_key);
+            assert_eq!(Some(v.clone()), deleted_value);
+        }
+    }
+}

--- a/libtransact/src/receipts.rs
+++ b/libtransact/src/receipts.rs
@@ -32,6 +32,19 @@ pub enum StateChange<K, V> {
     Delete { key: K },
 }
 
+impl<K: PartialEq, V> StateChange<K, V> {
+    /// Compares StateChanges based on the key, regardless of variant
+    pub fn has_key(&self, k: &K) -> bool {
+        if let StateChange::Set { key, .. } = self {
+            key == k
+        } else if let StateChange::Delete { key } = self {
+            key == k
+        } else {
+            false
+        }
+    }
+}
+
 impl<K, V> Clone for StateChange<K, V>
 where
     K: Clone,

--- a/libtransact/src/state/mod.rs
+++ b/libtransact/src/state/mod.rs
@@ -22,7 +22,7 @@
 //! and a way to purge old state, respectively, to an underlying storage mechanism.
 
 pub mod change_log;
-mod error;
+pub mod error;
 pub mod hashmap;
 pub mod merkle;
 pub mod merkle_error;


### PR DESCRIPTION
Reopening previous PR #31 

Adds initial implementation of the Context Manager and Context objects. This allows for Contexts to be created and altered with StateChanges. Also allows for the lookup of keys within Contexts and State.

Some functionality worth noting (and am open to other thoughts on how to implement this piece) is the addition of the `StateChangeResult` which is an enum based on the `StateChange` added to a Context. With a` StateChange::Set`, the `StateChangeResult` will return just the key that was set, and with a `StateChange::Delete`, the `StateChangeResult` will return the value that was deleted.

Also, the `drop_context` function is currently unimplemented as it seemed as though there could be more discussion on this function.