### PR TITLE
Remove mutex

### DIFF
--- a/libtransact/src/state/merkle.rs
+++ b/libtransact/src/state/merkle.rs
@@ -844,7 +844,7 @@ mod tests {
     use crate::database::error::DatabaseError;
     use crate::database::lmdb::{DatabaseReader, LmdbContext, LmdbDatabase};
 
-    use super::{Read, StateChange, Write};
+    use super::StateChange;
     use crate::state::change_log::ChangeLogEntry;
 
     use rand::seq::IteratorRandom;


### PR DESCRIPTION
This PR 
- Refactors MerkleDatabase slightly to remove the use of Mutex wrapping root_node and root_hash. It creates a new struct MerkleState that wraps an LMDB database and implements the Read,
Write and Prune traits. MerkleState creates an instance of MerkleDatabase and call its methods
to perform read, write and prune operations.
- MerkleDatabase is renamed MerkleRadixTree. 
- Fix a few compiler warnings in the merkle test module