### PR TITLE
Implement a basic, lock-backed Threadsafe Context Manager

### DIFF
--- a/libtransact/src/context/manager.rs
+++ b/libtransact/src/context/manager.rs
@@ -274,6 +274,137 @@ impl ContextManager {
     }
 }
 
+pub mod sync {
+    //! This module provides a thread-safe ContextManager.
+    //!
+    //! For many uses of the context manager, it will need to be shared between multiple threads,
+    //! with some threads reading and writing to a context while others create contexts.
+    use super::*;
+
+    use std::sync::{Arc, Mutex};
+
+    /// A thread-safe ContextManager.
+    #[derive(Clone)]
+    pub struct ContextManager {
+        internal_manager: Arc<Mutex<super::ContextManager>>,
+    }
+
+    impl ContextManager {
+        /// Constructs a new Context Manager around a given state Read.
+        ///
+        /// The Read defines the state on which the context built.
+        pub fn new(
+            database: Box<dyn Read<StateId = String, Key = String, Value = Vec<u8>>>,
+        ) -> Self {
+            ContextManager {
+                internal_manager: Arc::new(Mutex::new(super::ContextManager {
+                    contexts: HashMap::new(),
+                    database,
+                })),
+            }
+        }
+
+        /// Return a set of values from a context.
+        ///
+        /// The values are returned as key-value tuples
+        ///
+        ///
+        /// # Errors
+        ///
+        /// Returns an error if the context id does not exist, or an error occurs while reading
+        /// from the underlying state.
+        pub fn get(
+            &self,
+            context_id: &ContextId,
+            keys: &[String],
+        ) -> Result<Vec<(String, Vec<u8>)>, ContextManagerError> {
+            self.internal_manager
+                .lock()
+                .expect("Lock in the get method was poisoned")
+                .get(context_id, keys)
+        }
+
+        /// # Errors
+        ///
+        /// Returns an error if the context id does not exist, or an error occurs while reading
+        /// from the underlying state.
+        pub fn set_state(
+            &self,
+            context_id: &ContextId,
+            key: String,
+            value: Vec<u8>,
+        ) -> Result<(), ContextManagerError> {
+            self.internal_manager
+                .lock()
+                .expect("Lock in set_state was poisoned")
+                .set_state(context_id, key, value)
+        }
+
+        pub fn delete_state(
+            &self,
+            context_id: &ContextId,
+            key: &str,
+        ) -> Result<Option<Vec<u8>>, ContextManagerError> {
+            self.internal_manager
+                .lock()
+                .expect("Lock in delete_state was poisoned")
+                .delete_state(context_id, key)
+        }
+
+        pub fn add_event(
+            &self,
+            context_id: &ContextId,
+            event: Event,
+        ) -> Result<(), ContextManagerError> {
+            self.internal_manager
+                .lock()
+                .expect("Lock in add_event was poisoned")
+                .add_event(context_id, event)
+        }
+
+        pub fn add_data(
+            &self,
+            context_id: &ContextId,
+            data: Vec<u8>,
+        ) -> Result<(), ContextManagerError> {
+            self.internal_manager
+                .lock()
+                .expect("Lock in add_data was poisoned")
+                .add_data(context_id, data)
+        }
+
+        pub fn create_context(
+            &self,
+            dependent_contexts: &[ContextId],
+            state_id: &str,
+        ) -> ContextId {
+            self.internal_manager
+                .lock()
+                .expect("Lock in create_context was poisoned")
+                .create_context(dependent_contexts, state_id)
+        }
+
+        pub fn get_transaction_receipt(
+            &self,
+            context_id: &ContextId,
+            transaction_id: &str,
+        ) -> Result<TransactionReceipt, ContextManagerError> {
+            self.internal_manager
+                .lock()
+                .expect("Lock in get_transaction_receipt was poisoned")
+                .get_transaction_receipt(context_id, transaction_id)
+        }
+
+        pub fn drop_context(&self, context_id: ContextId) {
+            self.internal_manager
+                .lock()
+                .expect("Lock in drop_context was poisoned")
+                .drop_context(context_id)
+        }
+    }
+
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/libtransact/src/context/manager.rs
+++ b/libtransact/src/context/manager.rs
@@ -245,10 +245,10 @@ impl ContextManager {
     /// Creates a Context, and returns the resulting ContextId.
     pub fn create_context(
         &mut self,
-        dependent_contexts: Vec<ContextId>,
+        dependent_contexts: &[ContextId],
         state_id: &str,
     ) -> ContextId {
-        let new_context = Context::new(state_id, dependent_contexts);
+        let new_context = Context::new(state_id, dependent_contexts.to_vec());
         self.contexts.insert(*new_context.id(), new_context.clone());
         *new_context.id()
     }
@@ -336,11 +336,11 @@ mod tests {
     #[test]
     fn create_contexts() {
         let (mut manager, state_id) = make_manager(None);
-        let first_context_id = manager.create_context(Vec::new(), &state_id);
+        let first_context_id = manager.create_context(&[], &state_id);
         assert!(!manager.contexts.is_empty());
         assert!(manager.contexts.get(&first_context_id).is_some());
 
-        let second_context_id = manager.create_context(Vec::new(), &state_id);
+        let second_context_id = manager.create_context(&[], &state_id);
         let second_context = manager.get_context(&second_context_id).unwrap();
         assert_eq!(&second_context_id, second_context.id());
         assert_eq!(manager.contexts.len(), 2);
@@ -349,7 +349,7 @@ mod tests {
     #[test]
     fn add_context_event() {
         let (mut manager, state_id) = make_manager(None);
-        let context_id = manager.create_context(Vec::new(), &state_id);
+        let context_id = manager.create_context(&[], &state_id);
         let event = EventBuilder::new()
             .with_event_type(EVENT_TYPE1.to_string())
             .with_attributes(vec![
@@ -368,7 +368,7 @@ mod tests {
     #[test]
     fn add_context_data() {
         let (mut manager, state_id) = make_manager(None);
-        let context_id = manager.create_context(Vec::new(), &state_id);
+        let context_id = manager.create_context(&[], &state_id);
 
         let data_add_result = manager.add_data(&context_id, BYTES2.to_vec());
         let context = manager.get_context(&context_id).unwrap();
@@ -380,7 +380,7 @@ mod tests {
     fn create_transaction_receipt() {
         let (mut manager, state_id) = make_manager(None);
 
-        let context_id = manager.create_context(Vec::new(), &state_id);
+        let context_id = manager.create_context(&[], &state_id);
         let mut context = manager.get_context(&context_id).unwrap();
         assert_eq!(&context_id, context.id());
 
@@ -419,7 +419,7 @@ mod tests {
     fn add_set_state_change() {
         let (mut manager, state_id) = make_manager(None);
 
-        let context_id = manager.create_context(Vec::new(), &state_id);
+        let context_id = manager.create_context(&[], &state_id);
 
         let set_result = manager.set_state(&context_id, KEY1.to_string(), BYTES3.to_vec());
         assert!(set_result.is_ok());
@@ -439,13 +439,13 @@ mod tests {
             value: BYTES1.to_vec(),
         }];
         let (mut manager, state_id) = make_manager(Some(state_changes));
-        let ancestor_context = manager.create_context(Vec::new(), &state_id);
+        let ancestor_context = manager.create_context(&[], &state_id);
 
         assert!(manager
             .set_state(&ancestor_context, KEY2.to_string(), BYTES2.to_vec())
             .is_ok());
 
-        let current_context_id = manager.create_context(vec![ancestor_context], &state_id);
+        let current_context_id = manager.create_context(&[ancestor_context], &state_id);
         assert!(manager
             .set_state(&current_context_id, KEY3.to_string(), BYTES3.to_vec())
             .is_ok());
@@ -479,11 +479,11 @@ mod tests {
             value: BYTES1.to_vec(),
         }];
         let (mut manager, state_id) = make_manager(Some(state_changes));
-        let ancestor_context = manager.create_context(Vec::new(), &state_id);
+        let ancestor_context = manager.create_context(&[], &state_id);
         let add_result = manager.set_state(&ancestor_context, KEY2.to_string(), BYTES2.to_vec());
         assert!(add_result.is_ok());
 
-        let context_id = manager.create_context(vec![ancestor_context], &state_id);
+        let context_id = manager.create_context(&[ancestor_context], &state_id);
 
         // Validates the result from adding the state change to the Context within the ContextManager.
         assert!(manager

--- a/libtransact/src/execution/adapter/error.rs
+++ b/libtransact/src/execution/adapter/error.rs
@@ -25,11 +25,11 @@ use std::{error::Error, fmt};
 #[derive(Debug)]
 pub enum ExecutionAdapterError {
     /// Executing the transaction took too much time and so abort
-    TimeoutError(TransactionPair),
+    TimeoutError(Box<TransactionPair>),
     /// This ExecutionAdaptor does not have the capability to process the `TransactionPair`
     /// given to it. This can happen due to a timing error in routing the `TransactionPair`
     /// to the `ExecutionAdapter`.
-    RoutingError(TransactionPair),
+    RoutingError(Box<TransactionPair>),
 
     GeneralExecutionError(Box<dyn Error>),
 }

--- a/libtransact/src/execution/adapter/test_adapter.rs
+++ b/libtransact/src/execution/adapter/test_adapter.rs
@@ -97,7 +97,9 @@ impl TestExecutionAdapterState {
         on_done(if self.available {
             Ok(ExecutionTaskCompletionNotification::Valid(context_id))
         } else {
-            Err(ExecutionAdapterError::RoutingError(transaction_pair))
+            Err(ExecutionAdapterError::RoutingError(Box::new(
+                transaction_pair,
+            )))
         });
     }
 

--- a/libtransact/src/execution/executer_internal.rs
+++ b/libtransact/src/execution/executer_internal.rs
@@ -257,7 +257,7 @@ impl ExecuterThread {
                                         );
                                         }
                                     }
-                                    Err(ExecutionAdapterError::TimeOutError(transaction_pair)) => {
+                                    Err(ExecutionAdapterError::TimeoutError(transaction_pair)) => {
                                         let sender = sender.clone();
 
                                         let execution_task =

--- a/libtransact/src/execution/executer_internal.rs
+++ b/libtransact/src/execution/executer_internal.rs
@@ -285,6 +285,9 @@ impl ExecuterThread {
                                             warn!("During retry of RoutingError: {}", err);
                                         }
                                     }
+                                    Err(ExecutionAdapterError::GeneralExecutionError(err)) => {
+                                        error!("General Execution Error: {}", err);
+                                    }
                                 }
                             });
                             execution_adapter.execute(pair, context_id, callback);

--- a/libtransact/src/execution/executer_internal.rs
+++ b/libtransact/src/execution/executer_internal.rs
@@ -261,7 +261,7 @@ impl ExecuterThread {
                                         let sender = sender.clone();
 
                                         let execution_task =
-                                            ExecutionTask::new(transaction_pair, context_id);
+                                            ExecutionTask::new(*transaction_pair, context_id);
                                         let execution_event = (res_sender, execution_task);
                                         if let Err(err) =
                                             sender.send(RegistrationExecutionEvent::Execution(
@@ -275,7 +275,7 @@ impl ExecuterThread {
                                         let sender = sender.clone();
 
                                         let execution_task =
-                                            ExecutionTask::new(transaction_pair, context_id);
+                                            ExecutionTask::new(*transaction_pair, context_id);
                                         let execution_event = (res_sender, execution_task);
                                         if let Err(err) =
                                             sender.send(RegistrationExecutionEvent::Execution(

--- a/libtransact/src/scheduler/mod.rs
+++ b/libtransact/src/scheduler/mod.rs
@@ -63,6 +63,7 @@ impl ExecutionTask {
 }
 
 /// Result from executing an invalid transaction.
+#[derive(Debug, PartialEq)]
 pub struct InvalidTransactionResult {
     /// Transaction identifier.
     pub transaction_id: String,
@@ -93,6 +94,7 @@ pub struct BatchExecutionResult {
     pub results: Vec<TransactionExecutionResult>,
 }
 
+#[derive(Debug, PartialEq)]
 pub enum ExecutionTaskCompletionNotification {
     /// The transation was invalid.
     Invalid(ContextId, InvalidTransactionResult),

--- a/libtransact/src/state/hashmap.rs
+++ b/libtransact/src/state/hashmap.rs
@@ -133,6 +133,10 @@ impl Read for HashMapState {
             .filter_map(|k| state.get(&k).cloned().map(|v| (k, v)))
             .collect())
     }
+
+    fn clone_box(&self) -> Box<Read<StateId = String, Key = String, Value = Vec<u8>>> {
+        Box::new(Clone::clone(self))
+    }
 }
 
 #[cfg(test)]

--- a/libtransact/src/state/merkle.rs
+++ b/libtransact/src/state/merkle.rs
@@ -126,6 +126,10 @@ impl Read for MerkleState {
             Ok(result)
         })
     }
+
+    fn clone_box(&self) -> Box<Read<StateId = String, Key = String, Value = Vec<u8>>> {
+        Box::new(Clone::clone(self))
+    }
 }
 
 impl Prune for MerkleState {

--- a/libtransact/src/state/mod.rs
+++ b/libtransact/src/state/mod.rs
@@ -1,5 +1,6 @@
 /*
  * Copyright 2018 Bitwise IO, Inc.
+ * Copyright 2019 Cargill Incorporated
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -147,7 +148,7 @@ pub trait Prune: Sync + Send + Clone {
 /// It provides the ability to read values from an underlying storage
 ///
 /// Implementations are expected to be thread-safe.
-pub trait Read: Sync + Send + Clone {
+pub trait Read: Send + Send {
     /// A reference to a checkpoint in state. It could be a merkle hash for
     /// a merkle database.
     type StateId;
@@ -171,4 +172,13 @@ pub trait Read: Sync + Send + Clone {
         state_id: &Self::StateId,
         keys: &[Self::Key],
     ) -> Result<HashMap<Self::Key, Self::Value>, StateReadError>;
+
+    fn clone_box(&self)
+        -> Box<Read<StateId = Self::StateId, Key = Self::Key, Value = Self::Value>>;
+}
+
+impl<S, K, V> Clone for Box<Read<StateId = S, Key = K, Value = V>> {
+    fn clone(&self) -> Box<Read<StateId = S, Key = K, Value = V>> {
+        self.clone_box()
+    }
 }


### PR DESCRIPTION
Additionally, contains so other changes, such as removing the need for generic `Read` on the ContextManager, removing clone from `Read`, some context manager argument changes, and some error cleanup.