### PR TITLE
Add ContextManager error module

### DIFF
--- a/libtransact/src/context/error.rs
+++ b/libtransact/src/context/error.rs
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 Bitwise IO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+use std::error::Error;
+
+use crate::protocol::receipt::TransactionReceiptBuilderError;
+use crate::state::error::StateReadError;
+
+#[derive(Debug)]
+pub enum ContextManagerError {
+    MissingContextError(String),
+    TransactionReceiptBuilderError(TransactionReceiptBuilderError),
+    StateReadError(StateReadError),
+}
+
+impl Error for ContextManagerError {
+    fn description(&self) -> &str {
+        match *self {
+            ContextManagerError::MissingContextError(ref msg) => msg,
+            ContextManagerError::TransactionReceiptBuilderError(ref err) => err.description(),
+            ContextManagerError::StateReadError(ref err) => err.description(),
+        }
+    }
+
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match *self {
+            ContextManagerError::MissingContextError(_) => Some(self),
+            ContextManagerError::TransactionReceiptBuilderError(ref err) => Some(err),
+            ContextManagerError::StateReadError(ref err) => Some(err),
+        }
+    }
+}
+
+impl std::fmt::Display for ContextManagerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            ContextManagerError::MissingContextError(ref s) => {
+                write!(f, "Unable to find specified Context: {:?}", s)
+            }
+            ContextManagerError::TransactionReceiptBuilderError(ref err) => {
+                write!(f, "A TransactionReceiptBuilder error occured: {}", err)
+            }
+            ContextManagerError::StateReadError(ref err) => {
+                write!(f, "A State Read error occured: {}", err)
+            }
+        }
+    }
+}
+
+impl From<TransactionReceiptBuilderError> for ContextManagerError {
+    fn from(err: TransactionReceiptBuilderError) -> Self {
+        ContextManagerError::TransactionReceiptBuilderError(err)
+    }
+}
+
+impl From<StateReadError> for ContextManagerError {
+    fn from(err: StateReadError) -> Self {
+        ContextManagerError::StateReadError(err)
+    }
+}

--- a/libtransact/src/context/manager.rs
+++ b/libtransact/src/context/manager.rs
@@ -15,64 +15,14 @@
  * limitations under the License.
  * -----------------------------------------------------------------------------
  */
-
 use std::collections::HashMap;
 use std::collections::VecDeque;
-use std::error::Error as StdError;
 use std::str;
 
+pub use crate::context::error::ContextManagerError;
 use crate::context::{Context, ContextId, ContextLifecycle};
-use crate::protocol::receipt::{
-    Event, StateChange, TransactionReceipt, TransactionReceiptBuilder,
-    TransactionReceiptBuilderError,
-};
-use crate::state::error::StateReadError;
+use crate::protocol::receipt::{Event, StateChange, TransactionReceipt, TransactionReceiptBuilder};
 use crate::state::Read;
-
-#[derive(Debug)]
-pub enum ContextManagerError {
-    MissingContextError(String),
-    TransactionReceiptBuilderError(TransactionReceiptBuilderError),
-    StateReadError(StateReadError),
-}
-
-impl StdError for ContextManagerError {
-    fn description(&self) -> &str {
-        match *self {
-            ContextManagerError::MissingContextError(ref msg) => msg,
-            ContextManagerError::TransactionReceiptBuilderError(ref err) => err.description(),
-            ContextManagerError::StateReadError(ref err) => err.description(),
-        }
-    }
-}
-
-impl std::fmt::Display for ContextManagerError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match *self {
-            ContextManagerError::MissingContextError(ref s) => {
-                write!(f, "Unable to find specified Context: {:?}", s)
-            }
-            ContextManagerError::TransactionReceiptBuilderError(ref err) => {
-                write!(f, "A TransactionReceiptBuilder error occured: {}", err)
-            }
-            ContextManagerError::StateReadError(ref err) => {
-                write!(f, "A State Read error occured: {}", err)
-            }
-        }
-    }
-}
-
-impl From<TransactionReceiptBuilderError> for ContextManagerError {
-    fn from(err: TransactionReceiptBuilderError) -> Self {
-        ContextManagerError::TransactionReceiptBuilderError(err)
-    }
-}
-
-impl From<StateReadError> for ContextManagerError {
-    fn from(err: StateReadError) -> Self {
-        ContextManagerError::StateReadError(err)
-    }
-}
 
 pub struct ContextManager {
     contexts: HashMap<ContextId, Context>,

--- a/libtransact/src/context/mod.rs
+++ b/libtransact/src/context/mod.rs
@@ -19,6 +19,7 @@
 /// modify events, data, and state.
 pub type ContextId = [u8; 16];
 
+mod error;
 pub mod manager;
 
 use crate::context::manager::ContextManagerError;


### PR DESCRIPTION
Moves the errors used in the ContextManager to a separate module.

Signed-off-by: Shannyn Telander <telander@bitwise.io>