### PR TITLE
Static Execution Adapter

### DIFF
--- a/libtransact/src/execution/adapter/error.rs
+++ b/libtransact/src/execution/adapter/error.rs
@@ -31,7 +31,7 @@ pub enum ExecutionAdapterError {
     /// to the `ExecutionAdapter`.
     RoutingError(Box<TransactionPair>),
 
-    GeneralExecutionError(Box<dyn Error>),
+    GeneralExecutionError(Box<dyn Error + Send>),
 }
 
 impl Error for ExecutionAdapterError {

--- a/libtransact/src/execution/adapter/error.rs
+++ b/libtransact/src/execution/adapter/error.rs
@@ -65,3 +65,27 @@ impl fmt::Display for ExecutionAdapterError {
         }
     }
 }
+
+#[derive(Debug)]
+pub enum ExecutionOperationError {
+    /// An error occurred on `ExecutionAdaptor.start`
+    StartError(String),
+
+    /// An error occurred on `ExecutionAdaptor.execute`
+    ExecuteError(String),
+
+    /// An error occurred on `ExecutionAdaptor.stop`
+    StopError(String),
+}
+
+impl Error for ExecutionOperationError {}
+
+impl fmt::Display for ExecutionOperationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ExecutionOperationError::StartError(s) => write!(f, "Start Error: {}", s),
+            ExecutionOperationError::ExecuteError(s) => write!(f, "Execute Error: {}", s),
+            ExecutionOperationError::StopError(s) => write!(f, "Execute Error: {}", s),
+        }
+    }
+}

--- a/libtransact/src/execution/adapter/mod.rs
+++ b/libtransact/src/execution/adapter/mod.rs
@@ -23,7 +23,7 @@ pub mod static_adapter;
 #[cfg(test)]
 pub mod test_adapter;
 
-pub use crate::execution::adapter::error::ExecutionAdapterError;
+pub use crate::execution::adapter::error::{ExecutionAdapterError, ExecutionOperationError};
 
 use crate::context::ContextId;
 use crate::execution::ExecutionRegistry;
@@ -33,7 +33,10 @@ use crate::scheduler::ExecutionTaskCompletionNotification;
 /// Implementers of this trait proxy the transaction to the correct component to execute
 /// the transaction.
 pub trait ExecutionAdapter: Send {
-    fn start(&mut self, execution_registry: Box<dyn ExecutionRegistry>);
+    fn start(
+        &mut self,
+        execution_registry: Box<dyn ExecutionRegistry>,
+    ) -> Result<(), ExecutionOperationError>;
 
     /// Execute the transaction and provide an callback that handles the result.
     ///
@@ -47,8 +50,8 @@ pub trait ExecutionAdapter: Send {
         on_done: Box<
             dyn Fn(Result<ExecutionTaskCompletionNotification, ExecutionAdapterError>) + Send,
         >,
-    );
+    ) -> Result<(), ExecutionOperationError>;
 
     /// Stop the internal threads and the Executor will no longer call execute.
-    fn stop(self: Box<Self>) -> bool;
+    fn stop(self: Box<Self>) -> Result<(), ExecutionOperationError>;
 }

--- a/libtransact/src/execution/adapter/mod.rs
+++ b/libtransact/src/execution/adapter/mod.rs
@@ -43,7 +43,9 @@ pub trait ExecutionAdapter: Send {
         &self,
         transaction_pair: TransactionPair,
         context_id: ContextId,
-        on_done: Box<dyn Fn(Result<ExecutionTaskCompletionNotification, ExecutionAdapterError>)>,
+        on_done: Box<
+            dyn Fn(Result<ExecutionTaskCompletionNotification, ExecutionAdapterError>) + Send,
+        >,
     );
 
     /// Stop the internal threads and the Executor will no longer call execute.

--- a/libtransact/src/execution/adapter/mod.rs
+++ b/libtransact/src/execution/adapter/mod.rs
@@ -19,6 +19,7 @@
 //! and its associated state.
 
 mod error;
+pub mod static_adapter;
 #[cfg(test)]
 pub mod test_adapter;
 

--- a/libtransact/src/execution/adapter/static_adapter.rs
+++ b/libtransact/src/execution/adapter/static_adapter.rs
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+//! The static execution adapter provides a way to execute transaction handlers directly.
+//!
+//! This module provides the `StaticExecutionAdapter`, an implementation of `ExecutionAdapter`
+//! which execute transactions via `TransactionHandler` instances directly.
+use std::sync::mpsc::{channel, Sender};
+use std::thread;
+
+use crate::context::manager::sync::ContextManager;
+use crate::context::manager::ContextManagerError;
+use crate::context::ContextId;
+use crate::execution::adapter::{ExecutionAdapter, ExecutionAdapterError};
+use crate::execution::{ExecutionRegistry, TransactionFamily};
+use crate::handler::{ApplyError, ContextError, TransactionContext, TransactionHandler};
+use crate::protocol::receipt::Event;
+use crate::protocol::transaction::TransactionPair;
+use crate::scheduler::{ExecutionTaskCompletionNotification, InvalidTransactionResult};
+
+// A type declaration to make the use of this complicated type-bounded box easier to work with
+type OnDoneCallback =
+    Box<dyn Fn(Result<ExecutionTaskCompletionNotification, ExecutionAdapterError>) + Send>;
+
+/// The StaticExecutionAdapter to wrap TransactionHandlers
+///
+/// This struct takes a series of transaction handlers which can be used to execution transactions.
+/// These transactions are executed on a single background thread.
+pub struct StaticExecutionAdapter {
+    join_handle: thread::JoinHandle<bool>,
+    sender: Sender<StaticAdapterCommand>,
+}
+
+impl StaticExecutionAdapter {
+    /// Creates a new adapter, if possible.
+    ///
+    /// Creates a `StaticExecutionAdapter` wrapping the given `TransactionHandler` vector and a
+    /// `ContextManager` instance. This adapter will dispatch transaction pairs to the appropriate
+    /// handler, if found.
+    ///
+    /// # Errors
+    ///
+    /// `ExecutionAdapterError` is returned if the background thread cannot be created.
+    pub fn new_adapter(
+        handlers: Vec<Box<dyn TransactionHandler>>,
+        context_manager: ContextManager,
+    ) -> Result<Self, ExecutionAdapterError> {
+        let (sender, receiver) = channel();
+        let join_handle = thread::Builder::new()
+            .name("StaticExecutionAdapter".into())
+            .spawn(move || {
+                while let Ok(cmd) = receiver.recv() {
+                    match cmd {
+                        StaticAdapterCommand::Execute(execute_cmd) => {
+                            let (txn_pair, context_id, on_done) = *execute_cmd;
+                            debug!("Executing {:?} in context {:?}", &txn_pair, &context_id);
+                            execute_transaction(
+                                &handlers,
+                                txn_pair,
+                                &context_manager,
+                                context_id,
+                                on_done,
+                            );
+                        }
+                        StaticAdapterCommand::Start(mut execution_registry) => {
+                            register_handlers(&handlers, &mut *execution_registry);
+                        }
+                        StaticAdapterCommand::Stop => {
+                            break;
+                        }
+                    }
+                }
+                true
+            })
+            .map_err(|err| ExecutionAdapterError::GeneralExecutionError(Box::new(err)))?;
+
+        Ok(StaticExecutionAdapter {
+            join_handle,
+            sender,
+        })
+    }
+}
+
+fn execute_transaction(
+    handlers: &[Box<dyn TransactionHandler>],
+    transaction_pair: TransactionPair,
+    context_manager: &ContextManager,
+    context_id: ContextId,
+    on_done: OnDoneCallback,
+) {
+    let family = TransactionFamily::from_pair(&transaction_pair);
+    match handlers.iter().find(|handler| {
+        handler.family_name() == family.family_name()
+            && handler
+                .family_versions()
+                .iter()
+                .any(|v| v == family.family_version())
+    }) {
+        Some(handler) => {
+            let mut static_context = StaticContext::new(context_manager, &context_id);
+
+            match handler.apply(&transaction_pair, &mut static_context) {
+                Ok(_) => on_done(Ok(ExecutionTaskCompletionNotification::Valid(context_id))),
+                Err(ApplyError::InvalidTransaction(error_message)) => {
+                    on_done(Ok(ExecutionTaskCompletionNotification::Invalid(
+                        context_id,
+                        InvalidTransactionResult {
+                            transaction_id: transaction_pair
+                                .transaction()
+                                .header_signature()
+                                .to_owned(),
+                            error_message,
+                            error_data: vec![],
+                        },
+                    )))
+                }
+                Err(err) => on_done(Err(ExecutionAdapterError::GeneralExecutionError(Box::new(
+                    err,
+                )))),
+            }
+        }
+        None => on_done(Err(ExecutionAdapterError::RoutingError(Box::new(
+            transaction_pair,
+        )))),
+    };
+}
+
+fn register_handlers(
+    handlers: &[Box<dyn TransactionHandler>],
+    execution_registry: &mut ExecutionRegistry,
+) {
+    for handler in handlers {
+        for version in handler.family_versions() {
+            execution_registry.register_transaction_family(TransactionFamily::new(
+                handler.family_name().to_owned(),
+                version.clone(),
+            ));
+        }
+    }
+}
+
+impl ExecutionAdapter for StaticExecutionAdapter {
+    fn start(&mut self, execution_registry: Box<dyn ExecutionRegistry>) {
+        if let Err(err) = self
+            .sender
+            .send(StaticAdapterCommand::Start(execution_registry))
+        {
+            error!("Unable to submit start signal: {}", err);
+        }
+    }
+
+    fn execute(
+        &self,
+        transaction_pair: TransactionPair,
+        context_id: ContextId,
+        on_done: OnDoneCallback,
+    ) {
+        if let Err(err) = self.sender.send(StaticAdapterCommand::Execute(Box::new((
+            transaction_pair,
+            context_id,
+            on_done,
+        )))) {
+            error!("Unable to submit transaction for execution: {}", err);
+        }
+    }
+
+    fn stop(self: Box<Self>) -> bool {
+        if let Err(err) = self.sender.send(StaticAdapterCommand::Stop) {
+            error!("Unable to signal stop to static execution adapter: {}", err);
+            return false;
+        }
+
+        match self.join_handle.join() {
+            Ok(stopped) => stopped,
+            Err(_) => {
+                error!("Unable to stop static execution adapter");
+                false
+            }
+        }
+    }
+}
+
+enum StaticAdapterCommand {
+    Start(Box<dyn ExecutionRegistry>),
+    Stop,
+    Execute(Box<(TransactionPair, ContextId, OnDoneCallback)>),
+}
+
+struct StaticContext<'a, 'b> {
+    context_manager: &'a ContextManager,
+    context_id: &'b ContextId,
+}
+
+impl<'a, 'b> StaticContext<'a, 'b> {
+    fn new(context_manager: &'a ContextManager, context_id: &'b ContextId) -> Self {
+        StaticContext {
+            context_manager,
+            context_id,
+        }
+    }
+}
+
+impl<'a, 'b> TransactionContext for StaticContext<'a, 'b> {
+    fn get_state_entries(
+        &self,
+        addresses: &[String],
+    ) -> Result<Vec<(String, Vec<u8>)>, ContextError> {
+        self.context_manager
+            .get(self.context_id, addresses)
+            .map_err(ContextError::from)
+    }
+
+    fn set_state_entries(&self, entries: Vec<(String, Vec<u8>)>) -> Result<(), ContextError> {
+        for (address, value) in entries.into_iter() {
+            self.context_manager
+                .set_state(self.context_id, address, value)?;
+        }
+
+        Ok(())
+    }
+
+    fn delete_state_entries(&self, addresses: &[String]) -> Result<Vec<String>, ContextError> {
+        let mut results = vec![];
+        for address in addresses.iter() {
+            if self
+                .context_manager
+                .delete_state(self.context_id, address.as_str())?
+                .is_some()
+            {
+                results.push(address.clone());
+            }
+        }
+        Ok(results)
+    }
+
+    fn add_receipt_data(&self, data: Vec<u8>) -> Result<(), ContextError> {
+        self.context_manager
+            .add_data(self.context_id, data)
+            .map_err(ContextError::from)
+    }
+
+    fn add_event(
+        &self,
+        event_type: String,
+        attributes: Vec<(String, String)>,
+        data: Vec<u8>,
+    ) -> Result<(), ContextError> {
+        self.context_manager
+            .add_event(
+                self.context_id,
+                Event {
+                    event_type,
+                    attributes,
+                    data,
+                },
+            )
+            .map_err(ContextError::from)
+    }
+}
+
+impl From<ContextManagerError> for ContextError {
+    fn from(err: ContextManagerError) -> Self {
+        // Error's should be addressed in the handler::error module.
+        ContextError::SendError(Box::new(err))
+    }
+}

--- a/libtransact/src/execution/adapter/test_adapter.rs
+++ b/libtransact/src/execution/adapter/test_adapter.rs
@@ -69,7 +69,9 @@ impl ExecutionAdapter for TestExecutionAdapter {
         &self,
         transaction_pair: TransactionPair,
         _context_id: ContextId,
-        on_done: Box<dyn Fn(Result<ExecutionTaskCompletionNotification, ExecutionAdapterError>)>,
+        on_done: Box<
+            dyn Fn(Result<ExecutionTaskCompletionNotification, ExecutionAdapterError>) + Send,
+        >,
     ) {
         self.state.lock().expect("mutex is not poisoned").execute(
             transaction_pair,
@@ -92,7 +94,9 @@ impl TestExecutionAdapterState {
         &self,
         transaction_pair: TransactionPair,
         context_id: ContextId,
-        on_done: Box<dyn Fn(Result<ExecutionTaskCompletionNotification, ExecutionAdapterError>)>,
+        on_done: Box<
+            dyn Fn(Result<ExecutionTaskCompletionNotification, ExecutionAdapterError>) + Send,
+        >,
     ) {
         on_done(if self.available {
             Ok(ExecutionTaskCompletionNotification::Valid(context_id))

--- a/libtransact/src/handler/mod.rs
+++ b/libtransact/src/handler/mod.rs
@@ -94,7 +94,7 @@ pub trait TransactionContext {
     /// # Arguments
     ///
     /// * `data` - the data to add
-    fn add_receipt_data(&self, data: &[u8]) -> Result<(), ContextError>;
+    fn add_receipt_data(&self, data: Vec<u8>) -> Result<(), ContextError>;
 
     /// add_event adds a new event to the execution result for this transaction.
     ///
@@ -110,7 +110,7 @@ pub trait TransactionContext {
         &self,
         event_type: String,
         attributes: Vec<(String, String)>,
-        data: &[u8],
+        data: Vec<u8>,
     ) -> Result<(), ContextError>;
 }
 

--- a/libtransact/src/handler/mod.rs
+++ b/libtransact/src/handler/mod.rs
@@ -114,7 +114,7 @@ pub trait TransactionContext {
     ) -> Result<(), ContextError>;
 }
 
-pub trait TransactionHandler {
+pub trait TransactionHandler: Send {
     /// TransactionHandler that defines the business logic for a new transaction family.
     /// The family_name, family_versions, and namespaces functions are
     /// used by the processor to route processing requests to the handler.

--- a/libtransact/src/handler/mod.rs
+++ b/libtransact/src/handler/mod.rs
@@ -27,7 +27,13 @@ pub trait TransactionContext {
     /// # Arguments
     ///
     /// * `address` - the address to fetch
-    fn get_state_entry(&self, address: &str) -> Result<Option<Vec<u8>>, ContextError>;
+    fn get_state_entry(&self, address: &str) -> Result<Option<Vec<u8>>, ContextError> {
+        Ok(self
+            .get_state_entries(&[address.to_string()])?
+            .into_iter()
+            .map(|(_, val)| val)
+            .next())
+    }
 
     /// get_state_entries queries the validator state for data at each of the
     /// addresses in the given list. The addresses that have been set
@@ -48,7 +54,9 @@ pub trait TransactionContext {
     ///
     /// * `address` - address of where to store the data
     /// * `data` - payload is the data to store at the address
-    fn set_state_entry(&self, address: String, data: Vec<u8>) -> Result<(), ContextError>;
+    fn set_state_entry(&self, address: String, data: Vec<u8>) -> Result<(), ContextError> {
+        self.set_state_entries(vec![(address, data)])
+    }
 
     /// set_state_entries requests that each address in the provided map be
     /// set in validator state to its corresponding value.
@@ -65,7 +73,12 @@ pub trait TransactionContext {
     /// # Arguments
     ///
     /// * `address` - the address to delete
-    fn delete_state_entry(&self, address: &str) -> Result<Option<String>, ContextError>;
+    fn delete_state_entry(&self, address: &str) -> Result<Option<String>, ContextError> {
+        Ok(self
+            .delete_state_entries(&[address.to_string()])?
+            .into_iter()
+            .next())
+    }
 
     /// delete_state_entries requests that each of the provided addresses be unset
     /// in validator state. A list of successfully deleted addresses

--- a/libtransact/src/workload/command.rs
+++ b/libtransact/src/workload/command.rs
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+//! A basic Command Transaction Family
+use std::error::Error;
+
+use crate::handler::{ApplyError, TransactionContext, TransactionHandler};
+use crate::protocol::transaction::{HashMethod, TransactionBuilder, TransactionPair};
+use crate::signing::hash::HashSigner;
+
+const COMMAND_FAMILY_NAME: &str = "command";
+const COMMAND_VERSION: &str = "0.1";
+
+#[derive(Default)]
+pub struct CommandTransactionHandler {
+    versions: Vec<String>,
+}
+
+impl CommandTransactionHandler {
+    pub fn new() -> Self {
+        CommandTransactionHandler {
+            versions: vec![COMMAND_VERSION.to_owned()],
+        }
+    }
+}
+
+impl TransactionHandler for CommandTransactionHandler {
+    fn family_name(&self) -> &str {
+        COMMAND_FAMILY_NAME
+    }
+
+    fn family_versions(&self) -> &[String] {
+        &self.versions
+    }
+
+    fn apply(
+        &self,
+        transaction_pair: &TransactionPair,
+        context: &mut dyn TransactionContext,
+    ) -> Result<(), ApplyError> {
+        let commands = parse_commands(transaction_pair.transaction().payload())
+            .map_err(|err| ApplyError::InvalidTransaction(err.to_string()))?;
+
+        for command in commands.into_iter() {
+            match command {
+                Command::Set { address, value } => {
+                    context.set_state_entry(address, value)?;
+                }
+                Command::Delete { address } => {
+                    context.delete_state_entry(&address)?;
+                }
+                Command::Get { address } => {
+                    context.get_state_entry(&address)?;
+                }
+                Command::Fail { error_msg } => {
+                    return Err(ApplyError::InvalidTransaction(error_msg));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub enum Command {
+    Set { address: String, value: Vec<u8> },
+    Delete { address: String },
+    Get { address: String },
+    Fail { error_msg: String },
+}
+
+impl std::fmt::Display for Command {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Command::Set {
+                ref address,
+                ref value,
+            } => write!(f, "set,{},{}", address, hex::encode(value)),
+            Command::Get { ref address } => write!(f, "get,{}", address),
+            Command::Delete { ref address } => write!(f, "del,{}", address),
+            Command::Fail { ref error_msg } => write!(f, "fail,{}", error_msg),
+        }
+    }
+}
+
+pub fn make_command_transaction(commands: &[Command]) -> TransactionPair {
+    let signer = HashSigner::new();
+    TransactionBuilder::new()
+        .with_batcher_public_key(vec![0u8, 0u8, 0u8, 0u8])
+        .with_family_name(COMMAND_FAMILY_NAME.to_owned())
+        .with_family_version(COMMAND_VERSION.to_owned())
+        .with_inputs(
+            commands
+                .iter()
+                .map(|cmd| match cmd {
+                    Command::Set { address, .. } | Command::Delete { address } => {
+                        Some(address.as_bytes().to_vec())
+                    }
+                    _ => None,
+                })
+                .filter(Option::is_some)
+                .map(Option::unwrap)
+                .collect(),
+        )
+        .with_outputs(
+            commands
+                .iter()
+                .map(|cmd| match cmd {
+                    Command::Set { address, .. } | Command::Delete { address } => {
+                        Some(address.as_bytes().to_vec())
+                    }
+                    _ => None,
+                })
+                .filter(Option::is_some)
+                .map(Option::unwrap)
+                .collect(),
+        )
+        .with_payload_hash_method(HashMethod::SHA512)
+        .with_payload(
+            commands
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("|")
+                .into_bytes(),
+        )
+        .build_pair(&signer)
+        .unwrap()
+}
+
+fn parse_commands(payload: &[u8]) -> Result<Vec<Command>, ParseCommandError> {
+    std::str::from_utf8(payload)
+        .map_err(|err| ParseCommandError(format!("Payload not valid utf8 bytes: {}", err)))?
+        .split("|")
+        .map(|s| s.parse())
+        .collect::<Result<Vec<Command>, ParseCommandError>>()
+}
+
+impl std::str::FromStr for Command {
+    type Err = ParseCommandError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut command_parts = s.split(',');
+
+        let command = command_parts.next().map(|s| s.to_lowercase());
+        match command {
+            Some(ref set) if set == "set" => {
+                let address = command_parts
+                    .next()
+                    .map(|s| s.to_owned())
+                    .ok_or_else(|| ParseCommandError("Cannot set without address".into()))?;
+
+                Ok(Command::Set {
+                    address,
+                    value: command_parts
+                        .next()
+                        .ok_or_else(|| ParseCommandError("Cannot set without a value".into()))
+                        .and_then(|v| {
+                            if v.is_empty() {
+                                Ok(vec![])
+                            } else {
+                                hex::decode(v).map_err(|err| {
+                                    ParseCommandError(format!("Invalid hex: {}", err))
+                                })
+                            }
+                        })?,
+                })
+            }
+            Some(ref del) if del == "del" => {
+                let address = command_parts
+                    .next()
+                    .map(|s| s.to_owned())
+                    .ok_or_else(|| ParseCommandError("Cannot delete without address".into()))?;
+
+                Ok(Command::Delete { address })
+            }
+            Some(ref get) if get == "get" => {
+                let address = command_parts
+                    .next()
+                    .map(|s| s.to_owned())
+                    .ok_or_else(|| ParseCommandError("Cannot get without address".into()))?;
+
+                Ok(Command::Get { address })
+            }
+            Some(ref fail) if fail == "fail" => {
+                let error_msg = command_parts
+                    .next()
+                    .map(|s| s.to_owned())
+                    .unwrap_or("".to_owned());
+
+                Ok(Command::Fail { error_msg })
+            }
+            Some(cmd) => Err(ParseCommandError(format!("No command {} supported", cmd))),
+            None => Err(ParseCommandError("No command included".into())),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ParseCommandError(String);
+
+impl Error for ParseCommandError {}
+
+impl std::fmt::Display for ParseCommandError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Unable to parse command: {}", self.0)
+    }
+}

--- a/libtransact/src/workload/mod.rs
+++ b/libtransact/src/workload/mod.rs
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2018 Bitwise IO, Inc.
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+pub mod command;
 pub mod error;
 pub mod xo;
 


### PR DESCRIPTION
Implement a static execution adapter which takes TransactionHandlers and dispatches transaction pairs based on the transaction family they specify.

This handler runs on a background thread, and all operations are sent to it via a channel.

Additionally, this PR modifies several traits and type bounds to include send, which is required for these items to be passed to background threads.