### PR TITLE
Add Constructor to MerkleState

### DIFF
--- a/libtransact/src/state/merkle.rs
+++ b/libtransact/src/state/merkle.rs
@@ -50,6 +50,12 @@ pub struct MerkleState {
     db: LmdbDatabase,
 }
 
+impl MerkleState {
+    pub fn new(db: LmdbDatabase) -> Self {
+        MerkleState { db }
+    }
+}
+
 impl Write for MerkleState {
     type StateId = String;
     type Key = String;


### PR DESCRIPTION
Add a public constructor for the `MerkleState` wrapper, to enable library users to use the object.