### PR TITLE
Simplify executor's use of notifiers

### DIFF
--- a/libtransact/src/execution/executor/internal.rs
+++ b/libtransact/src/execution/executor/internal.rs
@@ -25,11 +25,6 @@
 //                                                                                                --------- ExecutionAdapter
 //
 
-use crate::execution::adapter::{ExecutionAdapter, ExecutionAdapterError};
-use crate::execution::{ExecutionRegistry, TransactionFamily};
-use crate::scheduler::ExecutionTask;
-use crate::scheduler::ExecutionTaskCompletionNotification;
-use log::warn;
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::hash::{Hash, Hasher};
@@ -40,6 +35,13 @@ use std::sync::{
 };
 use std::thread::JoinHandle;
 use std::time::Duration;
+
+use log::warn;
+
+use crate::execution::adapter::{ExecutionAdapter, ExecutionAdapterError};
+use crate::scheduler::ExecutionTask;
+use crate::scheduler::ExecutionTaskCompletionNotification;
+use crate::execution::{ExecutionRegistry, TransactionFamily};
 
 /// The `TransactionPair` and `ContextId` along with where to send
 /// results.

--- a/libtransact/src/execution/executor/mod.rs
+++ b/libtransact/src/execution/executor/mod.rs
@@ -52,22 +52,8 @@ impl Executor {
 
             let mut reader = ExecutionTaskReader::new(index);
 
-            let readers = Arc::clone(&self.readers);
-
-            let done_callback = Box::new(move |index| {
-                debug!(
-                    "Callback called removing iterator adapter {} for SchedulerExecutionInterface",
-                    index
-                );
-
-                readers
-                    .lock()
-                    .expect("The ExecutionTaskReader mutex is poisoned")
-                    .remove(&index);
-            });
-
             reader
-                .start(task_iterator, notifier, sender, done_callback)
+                .start(task_iterator, notifier, sender)
                 .map_err(|err| {
                     ExecutorError::ResourcesUnavailable(err.description().to_string())
                 })?;

--- a/libtransact/src/execution/executor/mod.rs
+++ b/libtransact/src/execution/executor/mod.rs
@@ -298,5 +298,9 @@ mod tests {
                 .expect("The MockScheduler lock is poisoned")
                 .push(notification);
         }
+
+        fn clone_box(&self) -> Box<dyn ExecutionTaskCompletionNotifier> {
+            Box::new(self.clone())
+        }
     }
 }

--- a/libtransact/src/scheduler/mod.rs
+++ b/libtransact/src/scheduler/mod.rs
@@ -140,6 +140,14 @@ pub trait Scheduler {
 pub trait ExecutionTaskCompletionNotifier: Send {
     /// Sends a notification to the scheduler.
     fn notify(&self, notification: ExecutionTaskCompletionNotification);
+
+    fn clone_box(&self) -> Box<dyn ExecutionTaskCompletionNotifier>;
+}
+
+impl Clone for Box<ExecutionTaskCompletionNotifier> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
 }
 
 #[cfg(test)]

--- a/libtransact/src/scheduler/serial/execution.rs
+++ b/libtransact/src/scheduler/serial/execution.rs
@@ -65,6 +65,7 @@ impl Iterator for SerialExecutionTaskIterator {
     }
 }
 
+#[derive(Clone)]
 pub struct SerialExecutionTaskCompletionNotifier {
     tx: Sender<CoreMessage>,
 }
@@ -80,5 +81,9 @@ impl ExecutionTaskCompletionNotifier for SerialExecutionTaskCompletionNotifier {
         self.tx
             .send(CoreMessage::ExecutionResult(notification))
             .unwrap();
+    }
+
+    fn clone_box(&self) -> Box<dyn ExecutionTaskCompletionNotifier> {
+        Box::new(self.clone())
     }
 }


### PR DESCRIPTION
This PR removes a level of indirection for the execution task completion notifications.  The notifier, which is currently Send, now also provides clone through a `clone_box` and `Clone` implementation for boxed notifiers.  This allows the notifier to be sent directly to the execution adapter, instead of indirectly via a sender.

This removes the additional thread needed to receive the notifications and forward them to the notifier.

It also removes the callback for removing the reader from the list in the executor, though this was not being actively executed and also contained a dead-lock.

The removal of this thread, and the simplification improves the CPU utilization of the executor dramatically.

Additionally,

- Reorders use statements to follow the convention of std, external crate and internal crate

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>