### PR TITLE
Add Sawtooth Compatibility Layer

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -8,4 +8,7 @@ function clean_up {
 
 trap clean_up EXIT
 
-docker-compose -f docker/compose/docker-compose.yaml run --rm transact cargo test
+docker-compose -f docker/compose/docker-compose.yaml run --rm transact \
+   /bin/bash -c \
+   "cargo test && \
+    cargo test --manifest-path /project/transact/libtransact/Cargo.toml --features=sawtooth-compat"

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -26,6 +26,7 @@ sawtooth-sdk = { git = "https://github.com/hyperledger/sawtooth-sdk-rust", optio
 
 [dev-dependencies]
 rand_hc = "0.1"
+sawtooth-xo = { git = "https://github.com/hyperledger/sawtooth-sdk-rust" }
 
 [build-dependencies]
 protoc-rust = "2"

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -22,13 +22,15 @@ cbor-codec = "0.7"
 libc = ">=0.2.35"
 openssl = "0.10"
 uuid = { version = "0.7", features = ["v4"] }
+sawtooth-sdk = { git = "https://github.com/hyperledger/sawtooth-sdk-rust", optional = true }
 
 [dev-dependencies]
-sawtooth-sdk = { git = "https://github.com/hyperledger/sawtooth-sdk-rust" }
 rand_hc = "0.1"
 
 [build-dependencies]
 protoc-rust = "2"
 
 [features]
+default = []
 nightly = []
+sawtooth-compat = ["sawtooth-sdk"]

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -24,7 +24,7 @@ openssl = "0.10"
 uuid = { version = "0.7", features = ["v4"] }
 
 [dev-dependencies]
-sawtooth-sdk = "0.1"
+sawtooth-sdk = { git = "https://github.com/hyperledger/sawtooth-sdk-rust" }
 rand_hc = "0.1"
 
 [build-dependencies]

--- a/libtransact/src/lib.rs
+++ b/libtransact/src/lib.rs
@@ -23,6 +23,8 @@ pub mod handler;
 pub mod protocol;
 #[allow(renamed_and_removed_lints)]
 pub mod protos;
+#[cfg(feature = "sawtooth-compat")]
+pub mod sawtooth;
 pub mod scheduler;
 pub mod signing;
 pub mod state;

--- a/libtransact/src/protocol/batch.rs
+++ b/libtransact/src/protocol/batch.rs
@@ -265,7 +265,10 @@ mod tests {
     use super::*;
     use crate::signing::hash::HashSigner;
     use crate::signing::Signer;
+    #[cfg(feature = "sawtooth-compat")]
     use protobuf::Message;
+
+    #[cfg(feature = "sawtooth-compat")]
     use sawtooth_sdk;
 
     static KEY1: &str = "111111111111111111111111111111111111111111111111111111111111111111";
@@ -389,6 +392,7 @@ mod tests {
         assert_eq!(original.transaction_ids(), header.transaction_ids());
     }
 
+    #[cfg(feature = "sawtooth-compat")]
     #[test]
     fn batch_header_sawtooth10_compatibility() {
         // Create protobuf bytes using the Sawtooth SDK
@@ -438,6 +442,7 @@ mod tests {
         assert_eq!(true, batch.trace());
     }
 
+    #[cfg(feature = "sawtooth-compat")]
     #[test]
     fn batch_sawtooth10_compatibility() {}
 }

--- a/libtransact/src/protocol/receipt.rs
+++ b/libtransact/src/protocol/receipt.rs
@@ -442,6 +442,8 @@ impl TransactionReceiptBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "sawtooth-compat")]
     use sawtooth_sdk;
 
     static ADDRESS: &str = "5b7349700e158b598043efd6d7610345a75a00b22ac14c9278db53f586179a92b72fbd";
@@ -585,6 +587,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "sawtooth-compat")]
     #[test]
     fn transaction_receipt_sawtooth10_compatibility() {
         let mut proto_transaction_receipt =

--- a/libtransact/src/protocol/receipt.rs
+++ b/libtransact/src/protocol/receipt.rs
@@ -29,7 +29,7 @@ use std::error::Error as StdError;
 /// A `StateChange` represents the basic level of changes that can be applied to
 /// values in state.  This covers the setting of a key/value pair, or the
 /// deletion of a key.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum StateChange {
     Set { key: String, value: Vec<u8> },
     Delete { key: String },

--- a/libtransact/src/protocol/transaction.rs
+++ b/libtransact/src/protocol/transaction.rs
@@ -439,11 +439,15 @@ impl TransactionBuilder {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "sawtooth-compat")]
     use crate::protos;
     use crate::signing::hash::HashSigner;
     use crate::signing::Signer;
 
+    #[cfg(feature = "sawtooth-compat")]
     use protobuf::Message;
+
+    #[cfg(feature = "sawtooth-compat")]
     use sawtooth_sdk;
 
     static FAMILY_NAME: &str = "test_family";
@@ -644,6 +648,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "sawtooth-compat")]
     #[test]
     fn transaction_header_sawtooth10_compatibility() {
         // Create protobuf bytes using the Sawtooth SDK
@@ -715,6 +720,7 @@ mod tests {
         assert_eq!(BYTES2.to_vec(), transaction.payload());
     }
 
+    #[cfg(feature = "sawtooth-compat")]
     #[test]
     fn transaction_sawtooth10_compatibility() {
         // Create protobuf bytes using the Sawtooth SDK

--- a/libtransact/src/sawtooth.rs
+++ b/libtransact/src/sawtooth.rs
@@ -1,0 +1,228 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Sawtooth Compatibility Layer
+//!
+//! This module provides a compatibility layer for use with [Hyperledger
+//! Sawtooth](https://sawtooth.hyperledger.org) transaction families.  It provides adapters to
+//! allow the use of existing Sawtooth transaction families, implemented with the [Rust
+//! SDK](https://crates.io/crates/sawtooth-sdk), in an application built with Transact.
+//!
+//! Note, to use this module, the Transact library must have the `"sawtooth-compat"` feature
+//! enabled.
+
+use std::fmt::Write as FmtWrite;
+
+use sawtooth_sdk::messages::processor::TpProcessRequest;
+use sawtooth_sdk::messages::transaction::TransactionHeader as SawtoothTxnHeader;
+use sawtooth_sdk::processor::handler::{
+    ApplyError as SawtoothApplyError, ContextError as SawtoothContextError,
+    TransactionContext as SawtoothContext, TransactionHandler as SawtoothTransactionHandler,
+};
+
+use crate::handler::{ApplyError, ContextError, TransactionContext, TransactionHandler};
+use crate::protocol::transaction::{TransactionHeader, TransactionPair};
+
+/// Adapts a Sawtooth Transaction Handler to a Transact TransactionHandler.
+///
+/// This adapter allows Sawtooth SDK TransactionHandler implementations to be used with the
+/// Transact static execution adapters.  Existing Sawtooth transaction families and smart contract
+/// engines can then be compiled in to an application using Transact.
+///
+/// For example, the Sawtooth transaction handler for the [XO Transaction
+/// Family](https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_specifications/xo_transaction_family.html)
+/// can be adapted as follows:
+///
+///     # use sawtooth_xo::handler::XoTransactionHandler;
+///     # use transact::context::manager::sync::ContextManager;
+///     # use transact::database::btree::BTreeDatabase;
+///     # use transact::execution::adapter::static_adapter::StaticExecutionAdapter;
+///     # use transact::sawtooth::SawtoothToTransactHandlerAdapter;
+///     # use transact::state::merkle::{self, MerkleRadixTree, MerkleState};
+///     #
+///     # let db = Box::new(BTreeDatabase::new(&merkle::INDEXES));
+///     # let context_manager = ContextManager::new(Box::new(MerkleState::new(db.clone())));
+///     let execution_adapter = StaticExecutionAdapter::new_adapter(
+///         vec![Box::new(SawtoothToTransactHandlerAdapter::new(
+///             XoTransactionHandler::new(),
+///         ))],
+///         context_manager,
+///     );
+///     # let _ignore = execution_adapter;
+pub struct SawtoothToTransactHandlerAdapter<H: SawtoothTransactionHandler + Send> {
+    family_name: String,
+    family_versions: Vec<String>,
+    handler: H,
+}
+
+impl<H: SawtoothTransactionHandler + Send> SawtoothToTransactHandlerAdapter<H> {
+    /// Constructs a new Sawtooth to Transact handler adapter.
+    pub fn new(handler: H) -> Self {
+        SawtoothToTransactHandlerAdapter {
+            family_name: handler.family_name().clone(),
+            family_versions: handler.family_versions().clone(),
+            handler,
+        }
+    }
+}
+
+impl<H: SawtoothTransactionHandler + Send> TransactionHandler
+    for SawtoothToTransactHandlerAdapter<H>
+{
+    fn family_name(&self) -> &str {
+        &self.family_name
+    }
+
+    fn family_versions(&self) -> &[String] {
+        &self.family_versions
+    }
+
+    fn apply(
+        &self,
+        transaction_pair: &TransactionPair,
+        context: &mut dyn TransactionContext,
+    ) -> Result<(), ApplyError> {
+        let request = txn_pair_to_process_request(transaction_pair);
+        let mut context_adapter = TransactToSawtoothContextAdapter::new(context);
+        self.handler
+            .apply(&request, &mut context_adapter)
+            .map_err(|err| match err {
+                SawtoothApplyError::InvalidTransaction(error_message) => {
+                    ApplyError::InvalidTransaction(error_message)
+                }
+                SawtoothApplyError::InternalError(error_message) => {
+                    ApplyError::InternalError(error_message)
+                }
+            })
+    }
+}
+
+struct TransactToSawtoothContextAdapter<'a> {
+    transact_context: &'a TransactionContext,
+}
+
+impl<'a> TransactToSawtoothContextAdapter<'a> {
+    fn new(transact_context: &'a TransactionContext) -> Self {
+        TransactToSawtoothContextAdapter { transact_context }
+    }
+}
+
+impl<'a> SawtoothContext for TransactToSawtoothContextAdapter<'a> {
+    fn get_state_entry(&self, address: &str) -> Result<Option<Vec<u8>>, SawtoothContextError> {
+        let results = self
+            .transact_context
+            .get_state_entries(&[address.to_owned()])
+            .map_err(to_context_error)?;
+
+        // take the first item, if it exists
+        Ok(results.into_iter().next().map(|(_, v)| v))
+    }
+
+    fn get_state_entries(
+        &self,
+        addresses: &[String],
+    ) -> Result<Vec<(String, Vec<u8>)>, SawtoothContextError> {
+        self.transact_context
+            .get_state_entries(addresses)
+            .map_err(to_context_error)
+    }
+
+    fn set_state_entry(&self, address: String, data: Vec<u8>) -> Result<(), SawtoothContextError> {
+        self.set_state_entries(vec![(address, data)])
+    }
+
+    fn set_state_entries(
+        &self,
+        entries: Vec<(String, Vec<u8>)>,
+    ) -> Result<(), SawtoothContextError> {
+        self.transact_context
+            .set_state_entries(entries)
+            .map_err(to_context_error)
+    }
+
+    fn delete_state_entry(&self, address: &str) -> Result<Option<String>, SawtoothContextError> {
+        Ok(self
+            .delete_state_entries(&[address.to_owned()])?
+            .into_iter()
+            .next())
+    }
+
+    fn delete_state_entries(
+        &self,
+        addresses: &[String],
+    ) -> Result<Vec<String>, SawtoothContextError> {
+        self.transact_context
+            .delete_state_entries(addresses)
+            .map_err(to_context_error)
+    }
+
+    fn add_receipt_data(&self, data: &[u8]) -> Result<(), SawtoothContextError> {
+        self.transact_context
+            .add_receipt_data(data.to_vec())
+            .map_err(to_context_error)
+    }
+
+    fn add_event(
+        &self,
+        event_type: String,
+        attributes: Vec<(String, String)>,
+        data: &[u8],
+    ) -> Result<(), SawtoothContextError> {
+        self.transact_context
+            .add_event(event_type, attributes, data.to_vec())
+            .map_err(to_context_error)
+    }
+}
+
+fn txn_pair_to_process_request(transaction_pair: &TransactionPair) -> TpProcessRequest {
+    let mut process_request = TpProcessRequest::new();
+
+    let header = as_sawtooth_header(transaction_pair.header());
+    process_request.set_header(header);
+
+    let txn = transaction_pair.transaction();
+    process_request.set_payload(txn.payload().to_vec());
+    process_request.set_signature(txn.header_signature().to_owned());
+
+    process_request
+}
+
+fn as_sawtooth_header(header: &TransactionHeader) -> SawtoothTxnHeader {
+    let mut sawtooth_header = SawtoothTxnHeader::new();
+
+    sawtooth_header.set_family_name(header.family_name().to_owned());
+    sawtooth_header.set_family_version(header.family_version().to_owned());
+    sawtooth_header.set_signer_public_key(to_hex(&header.signer_public_key()));
+    sawtooth_header.set_batcher_public_key(to_hex(&header.batcher_public_key()));
+    sawtooth_header.set_dependencies(header.dependencies().iter().map(to_hex).collect());
+    sawtooth_header.set_inputs(header.inputs().iter().map(to_hex).collect());
+    sawtooth_header.set_outputs(header.outputs().iter().map(to_hex).collect());
+    sawtooth_header.set_nonce(to_hex(&header.nonce()));
+
+    sawtooth_header
+}
+
+fn to_hex<T: AsRef<[u8]>>(bytes: &T) -> String {
+    let bytes = bytes.as_ref();
+    let mut buf = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        write!(&mut buf, "{:0x}", b).unwrap(); // this can't fail
+    }
+    buf
+}
+
+fn to_context_error(err: ContextError) -> SawtoothContextError {
+    SawtoothContextError::ReceiveError(Box::new(err))
+}
+

--- a/libtransact/src/state/change_log.rs
+++ b/libtransact/src/state/change_log.rs
@@ -112,7 +112,10 @@ impl ChangeLogEntry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "sawtooth-compat")]
     use crate::protos;
+
+    #[cfg(feature = "sawtooth-compat")]
     use sawtooth_sdk;
 
     static BYTES1: [u8; 4] = [0x01, 0x02, 0x03, 0x04];
@@ -150,6 +153,7 @@ mod tests {
         )
     }
 
+    #[cfg(feature = "sawtooth-compat")]
     #[test]
     fn change_log_entry_receipt_sawtooth10_compatibility() {
         let mut proto_entry = sawtooth_sdk::messages::merkle::ChangeLogEntry::new();


### PR DESCRIPTION
Add a Sawtooth compatibility layer for using Sawtooth Transaction Handlers via the Transact static execution adapters.  This includes an initial test (more forthcoming).

Note that this also adds a Rust feature to libtransact called `sawtooth-compat`, under which all of the sawooth-sdk related operations are organized (from a dependency perspective).  The tests (from a CI perspective), include running with the default features (i.e. no Sawtooth) and with sawtooth compatibility enabled.