### PR TITLE
Threaded Context Manager

### DIFF
--- a/libtransact/src/context/error.rs
+++ b/libtransact/src/context/error.rs
@@ -26,6 +26,7 @@ pub enum ContextManagerError {
     MissingContextError(String),
     TransactionReceiptBuilderError(TransactionReceiptBuilderError),
     StateReadError(StateReadError),
+    InternalError(Box<dyn Error>),
 }
 
 impl Error for ContextManagerError {
@@ -34,6 +35,7 @@ impl Error for ContextManagerError {
             ContextManagerError::MissingContextError(ref msg) => msg,
             ContextManagerError::TransactionReceiptBuilderError(ref err) => err.description(),
             ContextManagerError::StateReadError(ref err) => err.description(),
+            ContextManagerError::InternalError(ref err) => err.description(),
         }
     }
 
@@ -42,6 +44,7 @@ impl Error for ContextManagerError {
             ContextManagerError::MissingContextError(_) => Some(self),
             ContextManagerError::TransactionReceiptBuilderError(ref err) => Some(err),
             ContextManagerError::StateReadError(ref err) => Some(err),
+            ContextManagerError::InternalError(ref err) => Some(&**err),
         }
     }
 }
@@ -58,6 +61,9 @@ impl std::fmt::Display for ContextManagerError {
             ContextManagerError::StateReadError(ref err) => {
                 write!(f, "A State Read error occured: {}", err)
             }
+            ContextManagerError::InternalError(ref err) => {
+                write!(f, "An internal error occured: {}", err)
+            }
         }
     }
 }
@@ -71,6 +77,30 @@ impl From<TransactionReceiptBuilderError> for ContextManagerError {
 impl From<StateReadError> for ContextManagerError {
     fn from(err: StateReadError) -> Self {
         ContextManagerError::StateReadError(err)
+    }
+}
+
+impl From<ContextManagerCoreError> for ContextManagerError {
+    fn from(err: ContextManagerCoreError) -> Self {
+        ContextManagerError::InternalError(Box::new(err))
+    }
+}
+
+impl From<RecvError> for ContextManagerError {
+    fn from(err: RecvError) -> Self {
+        ContextManagerError::InternalError(Box::new(err))
+    }
+}
+
+impl From<SendError<ContextOperationMessage>> for ContextManagerError {
+    fn from(err: SendError<ContextOperationMessage>) -> Self {
+        ContextManagerError::InternalError(Box::new(err))
+    }
+}
+
+impl From<SendError<ContextOperationResponse>> for ContextManagerError {
+    fn from(err: SendError<ContextOperationResponse>) -> Self {
+        ContextManagerError::InternalError(Box::new(err))
     }
 }
 

--- a/libtransact/src/context/error.rs
+++ b/libtransact/src/context/error.rs
@@ -15,7 +15,9 @@
  * -----------------------------------------------------------------------------
  */
 use std::error::Error;
+use std::sync::mpsc::{RecvError, SendError};
 
+use crate::context::manager::thread::{ContextOperationMessage, ContextOperationResponse};
 use crate::protocol::receipt::TransactionReceiptBuilderError;
 use crate::state::error::StateReadError;
 
@@ -69,5 +71,73 @@ impl From<TransactionReceiptBuilderError> for ContextManagerError {
 impl From<StateReadError> for ContextManagerError {
     fn from(err: StateReadError) -> Self {
         ContextManagerError::StateReadError(err)
+    }
+}
+
+#[derive(Debug)]
+pub enum ContextManagerCoreError {
+    HandlerSendError(SendError<ContextOperationMessage>),
+    CoreSendError(SendError<ContextOperationResponse>),
+    CoreReceiveError(RecvError),
+    HandlerError(String),
+}
+
+impl Error for ContextManagerCoreError {
+    fn description(&self) -> &str {
+        match *self {
+            ContextManagerCoreError::HandlerSendError(ref err) => err.description(),
+            ContextManagerCoreError::CoreSendError(ref err) => err.description(),
+            ContextManagerCoreError::CoreReceiveError(ref err) => err.description(),
+            ContextManagerCoreError::HandlerError(ref msg) => msg,
+        }
+    }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match *self {
+            ContextManagerCoreError::HandlerSendError(ref err) => Some(err),
+            ContextManagerCoreError::CoreSendError(ref err) => Some(err),
+            ContextManagerCoreError::CoreReceiveError(ref err) => Some(err),
+            ContextManagerCoreError::HandlerError(_) => Some(self),
+        }
+    }
+}
+
+impl std::fmt::Display for ContextManagerCoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            ContextManagerCoreError::HandlerSendError(ref err) => write!(
+                f,
+                "A Send Error occurred from the Context Manager handler: {}",
+                err
+            ),
+            ContextManagerCoreError::CoreSendError(ref err) => write!(
+                f,
+                "A Send Error occurred from the Context Manager thread: {}",
+                err
+            ),
+            ContextManagerCoreError::CoreReceiveError(ref err) => {
+                write!(f, "A RecvError occurred: {}", err)
+            }
+            ContextManagerCoreError::HandlerError(ref s) => {
+                write!(f, "Error occurred in the Context Manager handler: {}", s)
+            }
+        }
+    }
+}
+
+impl From<SendError<ContextOperationMessage>> for ContextManagerCoreError {
+    fn from(err: SendError<ContextOperationMessage>) -> Self {
+        ContextManagerCoreError::HandlerSendError(err)
+    }
+}
+
+impl From<SendError<ContextOperationResponse>> for ContextManagerCoreError {
+    fn from(err: SendError<ContextOperationResponse>) -> Self {
+        ContextManagerCoreError::CoreSendError(err)
+    }
+}
+
+impl From<RecvError> for ContextManagerCoreError {
+    fn from(err: RecvError) -> Self {
+        ContextManagerCoreError::CoreReceiveError(err)
     }
 }

--- a/libtransact/src/context/manager/mod.rs
+++ b/libtransact/src/context/manager/mod.rs
@@ -16,6 +16,7 @@
  * -----------------------------------------------------------------------------
  */
 pub mod sync;
+pub mod thread;
 
 use std::collections::HashMap;
 use std::collections::VecDeque;

--- a/libtransact/src/context/manager/mod.rs
+++ b/libtransact/src/context/manager/mod.rs
@@ -44,7 +44,7 @@ impl ContextLifecycle for ContextManager {
         Ok(*new_context.id())
     }
 
-    fn drop_context(&mut self, _context_id: ContextId) {
+    fn drop_context(&mut self, _context_id: ContextId) -> Result<(), ContextManagerError> {
         unimplemented!();
     }
 

--- a/libtransact/src/context/manager/sync.rs
+++ b/libtransact/src/context/manager/sync.rs
@@ -115,7 +115,11 @@ impl ContextManager {
 
 impl ContextLifecycle for ContextManager {
     /// Creates a Context, and returns the resulting ContextId.
-    fn create_context(&mut self, dependent_contexts: &[ContextId], state_id: &str) -> ContextId {
+    fn create_context(
+        &mut self,
+        dependent_contexts: &[ContextId],
+        state_id: &str,
+    ) -> Result<ContextId, ContextManagerError> {
         self.internal_manager
             .lock()
             .expect("Lock in create_context was poisoned")

--- a/libtransact/src/context/manager/sync.rs
+++ b/libtransact/src/context/manager/sync.rs
@@ -126,7 +126,7 @@ impl ContextLifecycle for ContextManager {
             .create_context(dependent_contexts, state_id)
     }
 
-    fn drop_context(&mut self, context_id: ContextId) {
+    fn drop_context(&mut self, context_id: ContextId) -> Result<(), ContextManagerError> {
         self.internal_manager
             .lock()
             .expect("Lock in drop_context was poisoned")

--- a/libtransact/src/context/manager/thread/core.rs
+++ b/libtransact/src/context/manager/thread/core.rs
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use std::sync::mpsc::{Receiver, Sender};
+use std::thread;
+
+use crate::context::{manager::ContextManager, ContextId};
+use crate::protocol::receipt::{Event, TransactionReceipt};
+use crate::state::Read;
+
+/// An enum of messages which can be sent to the ContextManagerCore through a
+/// Sender<ContextOperationMessage>
+pub enum ContextOperationMessage {
+    Get {
+        handler_sender: Sender<ContextOperationResponse>,
+        context_id: ContextId,
+        keys: Vec<String>,
+    },
+    SetState {
+        handler_sender: Sender<ContextOperationResponse>,
+        context_id: ContextId,
+        key: String,
+        value: Vec<u8>,
+    },
+    DeleteState {
+        handler_sender: Sender<ContextOperationResponse>,
+        context_id: ContextId,
+        key: String,
+    },
+    AddEvent {
+        handler_sender: Sender<ContextOperationResponse>,
+        context_id: ContextId,
+        event: Event,
+    },
+    AddData {
+        handler_sender: Sender<ContextOperationResponse>,
+        context_id: ContextId,
+        data: Vec<u8>,
+    },
+    GetTransactionReceipt {
+        handler_sender: Sender<ContextOperationResponse>,
+        context_id: ContextId,
+        transaction_id: String,
+    },
+    CreateContext {
+        handler_sender: Sender<ContextOperationResponse>,
+        dependent_contexts: Vec<ContextId>,
+        state_id: String,
+    },
+    Shutdown,
+}
+
+/// An enum of response messages from the ContextManagerCore, which holds the result of
+/// ContextManager methods.
+pub enum ContextOperationResponse {
+    ValidResult {
+        result: Option<ContextOperationResult>,
+    },
+    InvalidResult {
+        error_message: String,
+    },
+}
+
+pub enum ContextOperationResult {
+    Get {
+        values: Vec<(String, Vec<u8>)>,
+    },
+    DeleteState {
+        value: Option<Vec<u8>>,
+    },
+    GetTransactionReceipt {
+        transaction_receipt: TransactionReceipt,
+    },
+    CreateContext {
+        context_id: ContextId,
+    },
+}
+
+struct ContextManagerCore {
+    /// Internal ContextManager owned by the threaded version.
+    _manager: ContextManager,
+
+    /// Receiver for all messages to the ContextManagerCore.
+    core_receiver: Receiver<ContextOperationMessage>,
+}
+
+impl ContextManagerCore {
+    fn new(
+        database: Box<dyn Read<StateId = String, Key = String, Value = Vec<u8>>>,
+        core_receiver: Receiver<ContextOperationMessage>,
+    ) -> Self {
+        let internal_manager = ContextManager::new(database);
+        ContextManagerCore {
+            _manager: internal_manager,
+            core_receiver,
+        }
+    }
+
+    fn run(&mut self) {
+        loop {
+            match self.core_receiver.recv() {
+                Ok(ContextOperationMessage::GetTransactionReceipt { .. }) => {
+                    unimplemented!();
+                }
+                Ok(ContextOperationMessage::CreateContext { .. }) => {
+                    unimplemented!();
+                }
+                Ok(ContextOperationMessage::Get { .. }) => {
+                    unimplemented!();
+                }
+                Ok(ContextOperationMessage::SetState { .. }) => {
+                    unimplemented!();
+                }
+                Ok(ContextOperationMessage::DeleteState { .. }) => {
+                    unimplemented!();
+                }
+                Ok(ContextOperationMessage::AddEvent { .. }) => {
+                    unimplemented!();
+                }
+                Ok(ContextOperationMessage::AddData { .. }) => {
+                    unimplemented!();
+                }
+                Ok(ContextOperationMessage::Shutdown) => {
+                    break;
+                }
+                Err(err) => {
+                    error!("ContextManagerCore recv error: {}", err);
+                    break;
+                }
+            }
+        }
+    }
+
+    fn start(mut self) -> std::thread::JoinHandle<()> {
+        thread::Builder::new()
+            .name(String::from("Thread-ContextManager"))
+            .spawn(move || {
+                self.run();
+            })
+            .expect("Could not build a thread for Context Manager")
+    }
+}

--- a/libtransact/src/context/manager/thread/core.rs
+++ b/libtransact/src/context/manager/thread/core.rs
@@ -146,12 +146,18 @@ impl ContextManagerCore {
                     dependent_contexts,
                     state_id,
                     handler_sender,
-                } => {
-                    let context_id = self.manager.create_context(&dependent_contexts, &state_id);
-                    handler_sender.send(ContextOperationResponse::ValidResult {
-                        result: Some(ContextOperationResult::CreateContext { context_id }),
-                    })?;
-                }
+                } => match self.manager.create_context(&dependent_contexts, &state_id) {
+                    Ok(context_id) => {
+                        handler_sender.send(ContextOperationResponse::ValidResult {
+                            result: Some(ContextOperationResult::CreateContext { context_id }),
+                        })?;
+                    }
+                    Err(err) => {
+                        handler_sender.send(ContextOperationResponse::InvalidResult {
+                            error_message: err.to_string(),
+                        })?;
+                    }
+                },
                 ContextOperationMessage::Get {
                     context_id,
                     keys,

--- a/libtransact/src/context/manager/thread/core.rs
+++ b/libtransact/src/context/manager/thread/core.rs
@@ -18,7 +18,9 @@
 use std::sync::mpsc::{Receiver, Sender};
 use std::thread;
 
-use crate::context::{error::ContextManagerCoreError, manager::ContextManager, ContextId};
+use crate::context::{
+    error::ContextManagerCoreError, manager::ContextManager, ContextId, ContextLifecycle,
+};
 use crate::protocol::receipt::{Event, TransactionReceipt};
 use crate::state::Read;
 
@@ -92,7 +94,7 @@ pub enum ContextOperationResult {
 
 struct ContextManagerCore {
     /// Internal ContextManager owned by the threaded version.
-    _manager: ContextManager,
+    manager: ContextManager,
 
     /// Receiver for all messages to the ContextManagerCore.
     core_receiver: Receiver<ContextOperationMessage>,
@@ -105,40 +107,127 @@ impl ContextManagerCore {
     ) -> Self {
         let internal_manager = ContextManager::new(database);
         ContextManagerCore {
-            _manager: internal_manager,
+            manager: internal_manager,
             core_receiver,
         }
     }
 
     fn run(&mut self) -> Result<(), ContextManagerCoreError> {
         loop {
-            match self.core_receiver.recv() {
-                Ok(ContextOperationMessage::GetTransactionReceipt { .. }) => {
-                    unimplemented!();
+            match self.core_receiver.recv()? {
+                ContextOperationMessage::GetTransactionReceipt {
+                    context_id,
+                    transaction_id,
+                    handler_sender,
+                } => {
+                    match self
+                        .manager
+                        .get_transaction_receipt(&context_id, &transaction_id)
+                    {
+                        Ok(txn_receipt) => {
+                            handler_sender.send(ContextOperationResponse::ValidResult {
+                                result: Some(ContextOperationResult::GetTransactionReceipt {
+                                    transaction_receipt: txn_receipt,
+                                }),
+                            })?;
+                        }
+                        Err(err) => {
+                            handler_sender.send(ContextOperationResponse::InvalidResult {
+                                error_message: err.to_string(),
+                            })?;
+                        }
+                    }
                 }
-                Ok(ContextOperationMessage::CreateContext { .. }) => {
-                    unimplemented!();
+                ContextOperationMessage::CreateContext {
+                    dependent_contexts,
+                    state_id,
+                    handler_sender,
+                } => {
+                    let context_id = self.manager.create_context(&dependent_contexts, &state_id);
+                    handler_sender.send(ContextOperationResponse::ValidResult {
+                        result: Some(ContextOperationResult::CreateContext { context_id }),
+                    })?;
                 }
-                Ok(ContextOperationMessage::Get { .. }) => {
-                    unimplemented!();
-                }
-                Ok(ContextOperationMessage::SetState { .. }) => {
-                    unimplemented!();
-                }
-                Ok(ContextOperationMessage::DeleteState { .. }) => {
-                    unimplemented!();
-                }
-                Ok(ContextOperationMessage::AddEvent { .. }) => {
-                    unimplemented!();
-                }
-                Ok(ContextOperationMessage::AddData { .. }) => {
-                    unimplemented!();
-                }
-                Ok(ContextOperationMessage::Shutdown) => {
+                ContextOperationMessage::Get {
+                    context_id,
+                    keys,
+                    handler_sender,
+                } => match self.manager.get(&context_id, &keys) {
+                    Ok(values) => {
+                        handler_sender.send(ContextOperationResponse::ValidResult {
+                            result: Some(ContextOperationResult::Get { values }),
+                        })?;
+                    }
+                    Err(err) => {
+                        handler_sender.send(ContextOperationResponse::InvalidResult {
+                            error_message: err.to_string(),
+                        })?;
+                    }
+                },
+                ContextOperationMessage::SetState {
+                    context_id,
+                    key,
+                    value,
+                    handler_sender,
+                } => match self.manager.set_state(&context_id, key, value) {
+                    Ok(()) => {
+                        handler_sender
+                            .send(ContextOperationResponse::ValidResult { result: None })?;
+                    }
+                    Err(err) => {
+                        handler_sender.send(ContextOperationResponse::InvalidResult {
+                            error_message: err.to_string(),
+                        })?;
+                    }
+                },
+                ContextOperationMessage::DeleteState {
+                    context_id,
+                    key,
+                    handler_sender,
+                } => match self.manager.delete_state(&context_id, &key) {
+                    Ok(value) => {
+                        handler_sender.send(ContextOperationResponse::ValidResult {
+                            result: Some(ContextOperationResult::DeleteState { value }),
+                        })?;
+                    }
+                    Err(err) => {
+                        handler_sender.send(ContextOperationResponse::InvalidResult {
+                            error_message: err.to_string(),
+                        })?;
+                    }
+                },
+                ContextOperationMessage::AddEvent {
+                    context_id,
+                    event,
+                    handler_sender,
+                } => match self.manager.add_event(&context_id, event) {
+                    Ok(()) => {
+                        handler_sender
+                            .send(ContextOperationResponse::ValidResult { result: None })?;
+                    }
+                    Err(err) => {
+                        handler_sender.send(ContextOperationResponse::InvalidResult {
+                            error_message: err.to_string(),
+                        })?;
+                    }
+                },
+                ContextOperationMessage::AddData {
+                    context_id,
+                    data,
+                    handler_sender,
+                } => match self.manager.add_data(&context_id, data) {
+                    Ok(()) => {
+                        handler_sender
+                            .send(ContextOperationResponse::ValidResult { result: None })?;
+                    }
+                    Err(err) => {
+                        handler_sender.send(ContextOperationResponse::InvalidResult {
+                            error_message: err.to_string(),
+                        })?;
+                    }
+                },
+                ContextOperationMessage::Shutdown => {
                     break;
-                }
-                Err(err) => {
-                    return Err(ContextManagerCoreError::CoreReceiveError(err));
                 }
             }
         }

--- a/libtransact/src/context/manager/thread/core.rs
+++ b/libtransact/src/context/manager/thread/core.rs
@@ -15,11 +15,15 @@
  * -----------------------------------------------------------------------------
  */
 
+use std::sync::mpsc;
 use std::sync::mpsc::{Receiver, Sender};
 use std::thread;
 
 use crate::context::{
-    error::ContextManagerCoreError, manager::ContextManager, ContextId, ContextLifecycle,
+    error::{ContextManagerCoreError, ContextManagerError},
+    manager::thread::ContextManager,
+    manager::ContextManager as InternalManager,
+    ContextId, ContextLifecycle,
 };
 use crate::protocol::receipt::{Event, TransactionReceipt};
 use crate::state::Read;
@@ -94,7 +98,7 @@ pub enum ContextOperationResult {
 
 struct ContextManagerCore {
     /// Internal ContextManager owned by the threaded version.
-    manager: ContextManager,
+    manager: InternalManager,
 
     /// Receiver for all messages to the ContextManagerCore.
     core_receiver: Receiver<ContextOperationMessage>,
@@ -105,7 +109,7 @@ impl ContextManagerCore {
         database: Box<dyn Read<StateId = String, Key = String, Value = Vec<u8>>>,
         core_receiver: Receiver<ContextOperationMessage>,
     ) -> Self {
-        let internal_manager = ContextManager::new(database);
+        let internal_manager = InternalManager::new(database);
         ContextManagerCore {
             manager: internal_manager,
             core_receiver,
@@ -243,5 +247,53 @@ impl ContextManagerCore {
                 }
             })
             .expect("Could not build a thread for Context Manager")
+    }
+}
+
+/// Used to spawn and shutdown a ContextManager thread.
+pub struct ContextManagerJoinHandle {
+    // Handle to the Context Manager Core
+    core_handle: Option<thread::JoinHandle<()>>,
+
+    // Used to send ContextOperationMessage to the Context Manager core.
+    // Dealt to individual ContextManagers to communicate with the ContextManagerCore.
+    core_sender: Sender<ContextOperationMessage>,
+}
+
+impl ContextManagerJoinHandle {
+    /// Creates a new ContextManager and ContextManager thread.
+    pub fn new(
+        database: Box<dyn Read<StateId = String, Key = String, Value = Vec<u8>>>,
+    ) -> (Self, ContextManager) {
+        let (core_sender, core_receiver) = mpsc::channel();
+        let handle = ContextManagerCore::new(database, core_receiver).start();
+        let context_manager = ContextManager::new(core_sender.clone());
+        (
+            ContextManagerJoinHandle {
+                core_handle: Some(handle),
+                core_sender,
+            },
+            context_manager,
+        )
+    }
+
+    /// Used to shutdown a ContextManager thread if the thread has not already been joined.
+    /// Returns an error if the thread has otherwise shutdown.
+    pub fn shutdown(mut self) -> Result<(), ContextManagerError> {
+        match self.core_sender.send(ContextOperationMessage::Shutdown) {
+            Ok(_) => {
+                if let Some(join_handle) = self.core_handle.take() {
+                    join_handle
+                        .join()
+                        .expect("Failed to join Context Manager core");
+                }
+            }
+            Err(err) => {
+                return Err(ContextManagerError::InternalError(Box::new(
+                    ContextManagerCoreError::HandlerSendError(err),
+                )));
+            }
+        }
+        Ok(())
     }
 }

--- a/libtransact/src/context/manager/thread/mod.rs
+++ b/libtransact/src/context/manager/thread/mod.rs
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+//! This module provides a threaded ContextManager.
+
+mod core;

--- a/libtransact/src/context/manager/thread/mod.rs
+++ b/libtransact/src/context/manager/thread/mod.rs
@@ -235,8 +235,28 @@ impl ContextLifecycle for ContextManager {
     }
 
     /// Drops the specified context from the ContextManager.
-    fn drop_context(&mut self, _context_id: ContextId) -> Result<(), ContextManagerError> {
-        unimplemented!();
+    fn drop_context(&mut self, context_id: ContextId) -> Result<(), ContextManagerError> {
+        let (handler_sender, handler_receiver) = mpsc::channel();
+
+        match self.core_sender.send(ContextOperationMessage::DropContext {
+            context_id,
+            handler_sender,
+        }) {
+            Ok(_) => {
+                if let ContextOperationResponse::ValidResult { result: None } =
+                    handler_receiver.recv()?
+                {
+                    Ok(())
+                } else {
+                    Err(ContextManagerError::InternalError(Box::new(
+                        ContextManagerCoreError::CoreReceiveError(RecvError),
+                    )))
+                }
+            }
+            Err(err) => Err(ContextManagerError::InternalError(Box::new(
+                ContextManagerCoreError::HandlerSendError(err),
+            ))),
+        }
     }
 
     ///Creates a TransactionReceipt based on the information available within the specified Context.

--- a/libtransact/src/context/manager/thread/mod.rs
+++ b/libtransact/src/context/manager/thread/mod.rs
@@ -27,7 +27,8 @@ use std::sync::mpsc;
 use std::sync::mpsc::{RecvError, Sender};
 
 use crate::context::error::{ContextManagerCoreError, ContextManagerError};
-use crate::context::{manager::thread::core::ContextOperationResult, ContextId};
+use crate::context::manager::thread::core::ContextOperationResult;
+use crate::context::{ContextId, ContextLifecycle};
 use crate::protocol::receipt::{Event, TransactionReceipt};
 
 /// A ContextManager which interacts with a threaded version of the ContextManager operations.
@@ -41,80 +42,6 @@ impl ContextManager {
     fn new(sender: Sender<ContextOperationMessage>) -> Self {
         ContextManager {
             core_sender: sender,
-        }
-    }
-
-    /// Returns a ContextId of the newly created Context.
-    pub fn create_context(
-        &mut self,
-        dependent_contexts: &[ContextId],
-        state_id: &str,
-    ) -> Result<ContextId, ContextManagerError> {
-        let (handler_sender, handler_receiver) = mpsc::channel();
-
-        match self
-            .core_sender
-            .send(ContextOperationMessage::CreateContext {
-                dependent_contexts: dependent_contexts.to_vec(),
-                state_id: state_id.to_string(),
-                handler_sender,
-            }) {
-            Ok(_) => {
-                if let ContextOperationResponse::ValidResult {
-                    result: Some(ContextOperationResult::CreateContext { context_id }),
-                } = handler_receiver.recv()?
-                {
-                    Ok(context_id)
-                } else {
-                    Err(ContextManagerError::InternalError(Box::new(
-                        ContextManagerCoreError::CoreReceiveError(RecvError),
-                    )))
-                }
-            }
-            Err(err) => Err(ContextManagerError::InternalError(Box::new(
-                ContextManagerCoreError::HandlerSendError(err),
-            ))),
-        }
-    }
-
-    /// Drops the specified context from the ContextManager.
-    pub fn drop_context(&mut self, _context_id: ContextId) {
-        unimplemented!();
-    }
-
-    /// Returns a TransactionReceipt based on the specified context.
-    pub fn get_transaction_receipt(
-        &self,
-        context_id: &ContextId,
-        transaction_id: &str,
-    ) -> Result<TransactionReceipt, ContextManagerError> {
-        let (handler_sender, handler_receiver) = mpsc::channel();
-
-        match self
-            .core_sender
-            .send(ContextOperationMessage::GetTransactionReceipt {
-                context_id: *context_id,
-                transaction_id: transaction_id.to_string(),
-                handler_sender,
-            }) {
-            Ok(_) => {
-                if let ContextOperationResponse::ValidResult {
-                    result:
-                        Some(ContextOperationResult::GetTransactionReceipt {
-                            transaction_receipt,
-                        }),
-                } = handler_receiver.recv()?
-                {
-                    Ok(transaction_receipt)
-                } else {
-                    Err(ContextManagerError::InternalError(Box::new(
-                        ContextManagerCoreError::CoreReceiveError(RecvError),
-                    )))
-                }
-            }
-            Err(err) => Err(ContextManagerError::InternalError(Box::new(
-                ContextManagerCoreError::HandlerSendError(err),
-            ))),
         }
     }
 
@@ -260,6 +187,82 @@ impl ContextManager {
                     handler_receiver.recv()?
                 {
                     Ok(())
+                } else {
+                    Err(ContextManagerError::InternalError(Box::new(
+                        ContextManagerCoreError::CoreReceiveError(RecvError),
+                    )))
+                }
+            }
+            Err(err) => Err(ContextManagerError::InternalError(Box::new(
+                ContextManagerCoreError::HandlerSendError(err),
+            ))),
+        }
+    }
+}
+
+impl ContextLifecycle for ContextManager {
+    /// Creates a new context, returning the resulting ContextId.
+    fn create_context(
+        &mut self,
+        dependent_contexts: &[ContextId],
+        state_id: &str,
+    ) -> Result<ContextId, ContextManagerError> {
+        let (handler_sender, handler_receiver) = mpsc::channel();
+
+        match self
+            .core_sender
+            .send(ContextOperationMessage::CreateContext {
+                dependent_contexts: dependent_contexts.to_vec(),
+                state_id: state_id.to_string(),
+                handler_sender,
+            }) {
+            Ok(_) => {
+                if let ContextOperationResponse::ValidResult {
+                    result: Some(ContextOperationResult::CreateContext { context_id }),
+                } = handler_receiver.recv()?
+                {
+                    Ok(context_id)
+                } else {
+                    Err(ContextManagerError::InternalError(Box::new(
+                        ContextManagerCoreError::CoreReceiveError(RecvError),
+                    )))
+                }
+            }
+            Err(err) => Err(ContextManagerError::InternalError(Box::new(
+                ContextManagerCoreError::HandlerSendError(err),
+            ))),
+        }
+    }
+
+    /// Drops the specified context from the ContextManager.
+    fn drop_context(&mut self, _context_id: ContextId) {
+        unimplemented!();
+    }
+
+    ///Creates a TransactionReceipt based on the information available within the specified Context.
+    fn get_transaction_receipt(
+        &self,
+        context_id: &ContextId,
+        transaction_id: &str,
+    ) -> Result<TransactionReceipt, ContextManagerError> {
+        let (handler_sender, handler_receiver) = mpsc::channel();
+
+        match self
+            .core_sender
+            .send(ContextOperationMessage::GetTransactionReceipt {
+                context_id: *context_id,
+                transaction_id: transaction_id.to_string(),
+                handler_sender,
+            }) {
+            Ok(_) => {
+                if let ContextOperationResponse::ValidResult {
+                    result:
+                        Some(ContextOperationResult::GetTransactionReceipt {
+                            transaction_receipt,
+                        }),
+                } = handler_receiver.recv()?
+                {
+                    Ok(transaction_receipt)
                 } else {
                     Err(ContextManagerError::InternalError(Box::new(
                         ContextManagerCoreError::CoreReceiveError(RecvError),

--- a/libtransact/src/context/manager/thread/mod.rs
+++ b/libtransact/src/context/manager/thread/mod.rs
@@ -272,3 +272,163 @@ impl ContextManager {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    use crate::protocol::receipt::{Event, EventBuilder, StateChange};
+    use crate::state::hashmap::HashMapState;
+
+    static KEY1: &str = "111111111111111111111111111111111111111111111111111111111111111111";
+    static KEY2: &str = "222222222222222222222222222222222222222222222222222222222222222222";
+    static KEY3: &str = "333333333333333333333333333333333333333333333333333333333333333333";
+    static KEY4: &str = "444444444444444444444444444444444444444444444444444444444444444444";
+
+    static BYTES1: [u8; 4] = [0x01, 0x02, 0x03, 0x04];
+    static BYTES2: [u8; 4] = [0x05, 0x06, 0x07, 0x08];
+    static BYTES3: [u8; 4] = [0x09, 0x10, 0x11, 0x12];
+
+    static EVENT_TYPE1: &str = "sawtooth/block-commit";
+    static ATTR1: (&str, &str) = (
+        "block_id",
+        "f40b90d06b4a9074af2ab09e0187223da7466be75ec0f472 \
+         f2edd5f22960d76e402e6c07c90b7816374891d698310dd25d9b88dce7dbcba8219d9f7c9cae1861",
+    );
+    static ATTR2: (&str, &str) = ("block_num", "3");
+
+    fn make_event() -> Event {
+        EventBuilder::new()
+            .with_event_type(EVENT_TYPE1.to_string())
+            .with_attributes(vec![
+                (ATTR1.0.to_string(), ATTR1.1.to_string()),
+                (ATTR2.0.to_string(), ATTR2.1.to_string()),
+            ])
+            .with_data(BYTES1.to_vec())
+            .build()
+            .unwrap()
+    }
+
+    fn check_state_change(state_change: StateChange) {
+        match state_change {
+            StateChange::Set { key, value } => {
+                assert_eq!(KEY2, key);
+                assert_eq!(BYTES2.to_vec(), value);
+            }
+            StateChange::Delete { key } => {
+                assert_eq!(KEY1, key);
+            }
+        }
+    }
+
+    fn check_transaction_receipt(transaction_receipt: TransactionReceipt, event: Event) {
+        for state_change in transaction_receipt.state_changes {
+            check_state_change(state_change)
+        }
+        assert_eq!(vec!(event), transaction_receipt.events);
+        assert_eq!(vec!(BYTES3.to_vec()), transaction_receipt.data);
+    }
+
+    /// Tests the functionality of the threaded Context Manager implemented through
+    /// the ContextLifecycle trait. The Context Manager's join handle is then used to shut down the
+    /// Context Manager thread.
+    #[test]
+    fn test_context_lifecycle() {
+        let state = HashMapState::new();
+        let (join_handle, context_manager) = ContextManagerJoinHandle::new(Box::new(state));
+
+        let state_id = HashMapState::state_id(&HashMap::new());
+
+        let context_id = context_manager.create_context(&[], &state_id);
+        assert!(context_id.is_ok());
+
+        let txn_receipt = context_manager.get_transaction_receipt(&context_id.unwrap(), KEY1);
+        assert!(txn_receipt.is_ok());
+        let transaction_id = txn_receipt.unwrap().transaction_id;
+        assert_eq!(transaction_id, KEY1.to_string());
+
+        assert!(join_handle.shutdown().is_ok());
+    }
+
+    /// Tests the threaded Context Manager functions dealing specifically with manipulating state,
+    /// including setting and deleting values from state, and fetching state to prove the correct
+    /// values are returned. The Context Manager's join handle is then used to shut down the Context
+    /// Manager thread.
+    #[test]
+    fn test_context_state_changes() {
+        let state = HashMapState::new();
+        let (join_handle, context_manager) = ContextManagerJoinHandle::new(Box::new(state));
+        let state_id = HashMapState::state_id(&HashMap::new());
+
+        let context_id = context_manager.create_context(&[], &state_id).unwrap();
+
+        let set_result = context_manager.set_state(&context_id, KEY1.to_string(), BYTES1.to_vec());
+        assert!(set_result.is_ok());
+        let set_result_2 =
+            context_manager.set_state(&context_id, KEY2.to_string(), BYTES2.to_vec());
+        assert!(set_result_2.is_ok());
+        let set_result_3 =
+            context_manager.set_state(&context_id, KEY3.to_string(), BYTES3.to_vec());
+        assert!(set_result_3.is_ok());
+
+        let delete_result = context_manager.delete_state(&context_id, KEY2).unwrap();
+        assert!(delete_result.is_some());
+        assert_eq!(Some(BYTES2.to_vec()), delete_result);
+        let delete_none_result = context_manager.delete_state(&context_id, KEY2).unwrap();
+        assert!(delete_none_result.is_none());
+
+        let keys = [KEY1.to_string(), KEY2.to_string(), KEY3.to_string()];
+        let mut key_values = context_manager.get_state(&context_id, &keys).unwrap();
+        assert_eq!(key_values.len(), 2);
+        assert_eq!(
+            key_values.pop().unwrap(),
+            (KEY1.to_string(), BYTES1.to_vec())
+        );
+        assert_eq!(
+            key_values.pop().unwrap(),
+            (KEY3.to_string(), BYTES3.to_vec())
+        );
+
+        assert!(join_handle.shutdown().is_ok());
+    }
+
+    /// Tests the functionality of the threaded Context Manager to be utilized on multiple threads
+    /// by setting state values using a clone of the generated Context Manager as well as adding
+    /// data to the cloned Context Manager on a thread spawned within the test. The original
+    /// Context Manager is then used to create a TransactionReceipt which holds the data and state
+    /// values set by the cloned Context Manager in the separate thread. The Context Manager's join
+    /// handle is then used to shut down the Context Manager thread.
+    #[test]
+    fn test_multi_thread_integration() {
+        let state = HashMapState::new();
+        let (join_handle, context_manager) = ContextManagerJoinHandle::new(Box::new(state));
+        let state_id = HashMapState::state_id(&HashMap::new());
+
+        let context_id = context_manager.create_context(&[], &state_id).unwrap();
+        let cm = context_manager.clone();
+
+        let _ = std::thread::Builder::new()
+            .name(String::from("Thread-test-populate-context"))
+            .spawn(move || {
+                assert!(cm.add_event(&context_id, make_event()).is_ok());
+                assert!(cm.add_data(&context_id, BYTES3.to_vec()).is_ok());
+                assert!(cm
+                    .set_state(&context_id, KEY1.to_string(), BYTES1.to_vec())
+                    .is_ok());
+                assert!(cm.delete_state(&context_id, KEY1).is_ok());
+                assert!(cm
+                    .set_state(&context_id, KEY2.to_string(), BYTES2.to_vec())
+                    .is_ok());
+            })
+            .unwrap()
+            .join();
+
+        let txn_receipt = context_manager
+            .get_transaction_receipt(&context_id, KEY4)
+            .unwrap();
+        check_transaction_receipt(txn_receipt, make_event());
+
+        assert!(join_handle.shutdown().is_ok());
+    }
+}

--- a/libtransact/src/context/manager/thread/mod.rs
+++ b/libtransact/src/context/manager/thread/mod.rs
@@ -18,3 +18,7 @@
 //! This module provides a threaded ContextManager.
 
 mod core;
+
+pub use crate::context::manager::thread::core::{
+    ContextOperationMessage, ContextOperationResponse,
+};

--- a/libtransact/src/context/manager/thread/mod.rs
+++ b/libtransact/src/context/manager/thread/mod.rs
@@ -235,7 +235,7 @@ impl ContextLifecycle for ContextManager {
     }
 
     /// Drops the specified context from the ContextManager.
-    fn drop_context(&mut self, _context_id: ContextId) {
+    fn drop_context(&mut self, _context_id: ContextId) -> Result<(), ContextManagerError> {
         unimplemented!();
     }
 

--- a/libtransact/src/context/manager/thread/mod.rs
+++ b/libtransact/src/context/manager/thread/mod.rs
@@ -20,7 +20,7 @@
 mod core;
 
 pub use crate::context::manager::thread::core::{
-    ContextOperationMessage, ContextOperationResponse,
+    ContextManagerJoinHandle, ContextOperationMessage, ContextOperationResponse,
 };
 
 use std::sync::mpsc;

--- a/libtransact/src/context/manager/thread/mod.rs
+++ b/libtransact/src/context/manager/thread/mod.rs
@@ -22,3 +22,253 @@ mod core;
 pub use crate::context::manager::thread::core::{
     ContextOperationMessage, ContextOperationResponse,
 };
+
+use std::sync::mpsc;
+use std::sync::mpsc::{RecvError, Sender};
+
+use crate::context::error::{ContextManagerCoreError, ContextManagerError};
+use crate::context::{manager::thread::core::ContextOperationResult, ContextId};
+use crate::protocol::receipt::{Event, TransactionReceipt};
+
+/// A ContextManager which interacts with a threaded version of the ContextManager operations.
+#[derive(Clone)]
+pub struct ContextManager {
+    /// Used to send ContextOperationMessage to the Context Manager core
+    core_sender: Sender<ContextOperationMessage>,
+}
+
+impl ContextManager {
+    fn new(sender: Sender<ContextOperationMessage>) -> Self {
+        ContextManager {
+            core_sender: sender,
+        }
+    }
+
+    /// Returns a ContextId of the newly created Context.
+    pub fn create_context(
+        &self,
+        dependent_contexts: &[ContextId],
+        state_id: &str,
+    ) -> Result<ContextId, ContextManagerError> {
+        let (handler_sender, handler_receiver) = mpsc::channel();
+
+        match self
+            .core_sender
+            .send(ContextOperationMessage::CreateContext {
+                dependent_contexts: dependent_contexts.to_vec(),
+                state_id: state_id.to_string(),
+                handler_sender,
+            }) {
+            Ok(_) => {
+                if let ContextOperationResponse::ValidResult {
+                    result: Some(ContextOperationResult::CreateContext { context_id }),
+                } = handler_receiver.recv()?
+                {
+                    Ok(context_id)
+                } else {
+                    Err(ContextManagerError::InternalError(Box::new(
+                        ContextManagerCoreError::CoreReceiveError(RecvError),
+                    )))
+                }
+            }
+            Err(err) => Err(ContextManagerError::InternalError(Box::new(
+                ContextManagerCoreError::HandlerSendError(err),
+            ))),
+        }
+    }
+
+    /// Drops the specified context from the ContextManager.
+    pub fn drop_context(&self, _context_id: ContextId) {
+        unimplemented!();
+    }
+
+    /// Returns a TransactionReceipt based on the specified context.
+    pub fn get_transaction_receipt(
+        &self,
+        context_id: &ContextId,
+        transaction_id: &str,
+    ) -> Result<TransactionReceipt, ContextManagerError> {
+        let (handler_sender, handler_receiver) = mpsc::channel();
+
+        match self
+            .core_sender
+            .send(ContextOperationMessage::GetTransactionReceipt {
+                context_id: *context_id,
+                transaction_id: transaction_id.to_string(),
+                handler_sender,
+            }) {
+            Ok(_) => {
+                if let ContextOperationResponse::ValidResult {
+                    result:
+                        Some(ContextOperationResult::GetTransactionReceipt {
+                            transaction_receipt,
+                        }),
+                } = handler_receiver.recv()?
+                {
+                    Ok(transaction_receipt)
+                } else {
+                    Err(ContextManagerError::InternalError(Box::new(
+                        ContextManagerCoreError::CoreReceiveError(RecvError),
+                    )))
+                }
+            }
+            Err(err) => Err(ContextManagerError::InternalError(Box::new(
+                ContextManagerCoreError::HandlerSendError(err),
+            ))),
+        }
+    }
+
+    /// Returns a list of key and value pairs from the specified context's state using the
+    /// list of keys.
+    pub fn get_state(
+        &self,
+        context_id: &ContextId,
+        keys: &[String],
+    ) -> Result<Vec<(String, Vec<u8>)>, ContextManagerError> {
+        let (handler_sender, handler_receiver) = mpsc::channel();
+        match self.core_sender.send(ContextOperationMessage::Get {
+            context_id: *context_id,
+            keys: keys.to_vec(),
+            handler_sender,
+        }) {
+            Ok(_) => {
+                if let ContextOperationResponse::ValidResult {
+                    result: Some(ContextOperationResult::Get { values }),
+                } = handler_receiver.recv()?
+                {
+                    Ok(values)
+                } else {
+                    Err(ContextManagerError::InternalError(Box::new(
+                        ContextManagerCoreError::CoreReceiveError(RecvError),
+                    )))
+                }
+            }
+            Err(err) => Err(ContextManagerError::InternalError(Box::new(
+                ContextManagerCoreError::HandlerSendError(err),
+            ))),
+        }
+    }
+
+    /// Sets a key and value pair in the specified context's state.
+    pub fn set_state(
+        &self,
+        context_id: &ContextId,
+        key: String,
+        value: Vec<u8>,
+    ) -> Result<(), ContextManagerError> {
+        let (handler_sender, handler_receiver) = mpsc::channel();
+
+        match self.core_sender.send(ContextOperationMessage::SetState {
+            context_id: *context_id,
+            key,
+            value,
+            handler_sender,
+        }) {
+            Ok(_) => {
+                if let ContextOperationResponse::ValidResult { result: None } =
+                    handler_receiver.recv()?
+                {
+                    Ok(())
+                } else {
+                    Err(ContextManagerError::InternalError(Box::new(
+                        ContextManagerCoreError::CoreReceiveError(RecvError),
+                    )))
+                }
+            }
+            Err(err) => Err(ContextManagerError::InternalError(Box::new(
+                ContextManagerCoreError::HandlerSendError(err),
+            ))),
+        }
+    }
+
+    /// Removes a specific key and all associated values from the specified context's state.
+    pub fn delete_state(
+        &self,
+        context_id: &ContextId,
+        key: &str,
+    ) -> Result<Option<Vec<u8>>, ContextManagerError> {
+        let (handler_sender, handler_receiver) = mpsc::channel();
+
+        match self.core_sender.send(ContextOperationMessage::DeleteState {
+            context_id: *context_id,
+            key: key.to_string(),
+            handler_sender,
+        }) {
+            Ok(_) => {
+                if let ContextOperationResponse::ValidResult {
+                    result: Some(ContextOperationResult::DeleteState { value }),
+                } = handler_receiver.recv()?
+                {
+                    Ok(value)
+                } else {
+                    Err(ContextManagerError::InternalError(Box::new(
+                        ContextManagerCoreError::CoreReceiveError(RecvError),
+                    )))
+                }
+            }
+            Err(err) => Err(ContextManagerError::InternalError(Box::new(
+                ContextManagerCoreError::HandlerSendError(err),
+            ))),
+        }
+    }
+
+    /// Adds an Event to the specified context's list of events.
+    pub fn add_event(
+        &self,
+        context_id: &ContextId,
+        event: Event,
+    ) -> Result<(), ContextManagerError> {
+        let (handler_sender, handler_receiver) = mpsc::channel();
+
+        match self.core_sender.send(ContextOperationMessage::AddEvent {
+            context_id: *context_id,
+            event,
+            handler_sender,
+        }) {
+            Ok(_) => {
+                if let ContextOperationResponse::ValidResult { result: None } =
+                    handler_receiver.recv()?
+                {
+                    Ok(())
+                } else {
+                    Err(ContextManagerError::InternalError(Box::new(
+                        ContextManagerCoreError::CoreReceiveError(RecvError),
+                    )))
+                }
+            }
+            Err(err) => Err(ContextManagerError::InternalError(Box::new(
+                ContextManagerCoreError::HandlerSendError(err),
+            ))),
+        }
+    }
+
+    /// Adds data, represented as `Vec<u8>`, to the specified context's list of data.
+    pub fn add_data(
+        &self,
+        context_id: &ContextId,
+        data: Vec<u8>,
+    ) -> Result<(), ContextManagerError> {
+        let (handler_sender, handler_receiver) = mpsc::channel();
+
+        match self.core_sender.send(ContextOperationMessage::AddData {
+            context_id: *context_id,
+            data,
+            handler_sender,
+        }) {
+            Ok(_) => {
+                if let ContextOperationResponse::ValidResult { result: None } =
+                    handler_receiver.recv()?
+                {
+                    Ok(())
+                } else {
+                    Err(ContextManagerError::InternalError(Box::new(
+                        ContextManagerCoreError::CoreReceiveError(RecvError),
+                    )))
+                }
+            }
+            Err(err) => Err(ContextManagerError::InternalError(Box::new(
+                ContextManagerCoreError::HandlerSendError(err),
+            ))),
+        }
+    }
+}

--- a/libtransact/src/context/manager/thread/mod.rs
+++ b/libtransact/src/context/manager/thread/mod.rs
@@ -46,7 +46,7 @@ impl ContextManager {
 
     /// Returns a ContextId of the newly created Context.
     pub fn create_context(
-        &self,
+        &mut self,
         dependent_contexts: &[ContextId],
         state_id: &str,
     ) -> Result<ContextId, ContextManagerError> {
@@ -78,7 +78,7 @@ impl ContextManager {
     }
 
     /// Drops the specified context from the ContextManager.
-    pub fn drop_context(&self, _context_id: ContextId) {
+    pub fn drop_context(&mut self, _context_id: ContextId) {
         unimplemented!();
     }
 
@@ -336,7 +336,7 @@ mod tests {
     #[test]
     fn test_context_lifecycle() {
         let state = HashMapState::new();
-        let (join_handle, context_manager) = ContextManagerJoinHandle::new(Box::new(state));
+        let (join_handle, mut context_manager) = ContextManagerJoinHandle::new(Box::new(state));
 
         let state_id = HashMapState::state_id(&HashMap::new());
 
@@ -358,7 +358,7 @@ mod tests {
     #[test]
     fn test_context_state_changes() {
         let state = HashMapState::new();
-        let (join_handle, context_manager) = ContextManagerJoinHandle::new(Box::new(state));
+        let (join_handle, mut context_manager) = ContextManagerJoinHandle::new(Box::new(state));
         let state_id = HashMapState::state_id(&HashMap::new());
 
         let context_id = context_manager.create_context(&[], &state_id).unwrap();
@@ -402,7 +402,7 @@ mod tests {
     #[test]
     fn test_multi_thread_integration() {
         let state = HashMapState::new();
-        let (join_handle, context_manager) = ContextManagerJoinHandle::new(Box::new(state));
+        let (join_handle, mut context_manager) = ContextManagerJoinHandle::new(Box::new(state));
         let state_id = HashMapState::state_id(&HashMap::new());
 
         let context_id = context_manager.create_context(&[], &state_id).unwrap();

--- a/libtransact/src/context/mod.rs
+++ b/libtransact/src/context/mod.rs
@@ -36,7 +36,11 @@ use uuid::Uuid;
 /// ContextManager functionality used by the Scheduler.
 pub trait ContextLifecycle: Send {
     /// Create a new Context, returning a unique ContextId.
-    fn create_context(&mut self, dependent_contexts: &[ContextId], state_id: &str) -> ContextId;
+    fn create_context(
+        &mut self,
+        dependent_contexts: &[ContextId],
+        state_id: &str,
+    ) -> Result<ContextId, ContextManagerError>;
 
     fn drop_context(&mut self, context_id: ContextId);
 

--- a/libtransact/src/context/mod.rs
+++ b/libtransact/src/context/mod.rs
@@ -42,7 +42,7 @@ pub trait ContextLifecycle: Send {
         state_id: &str,
     ) -> Result<ContextId, ContextManagerError>;
 
-    fn drop_context(&mut self, context_id: ContextId);
+    fn drop_context(&mut self, context_id: ContextId) -> Result<(), ContextManagerError>;
 
     fn get_transaction_receipt(
         &self,

--- a/libtransact/src/execution/adapter/static_adapter.rs
+++ b/libtransact/src/execution/adapter/static_adapter.rs
@@ -300,7 +300,7 @@ mod test {
         Arc,
     };
 
-    use crate::context::manager::thread::ContextManagerJoinHandle;
+    use crate::context::{manager::thread::ContextManagerJoinHandle, ContextLifecycle};
     use crate::scheduler::{ExecutionTaskCompletionNotification, InvalidTransactionResult};
     use crate::state::hashmap::HashMapState;
     use crate::workload::command::{make_command_transaction, Command, CommandTransactionHandler};

--- a/libtransact/src/execution/adapter/static_adapter.rs
+++ b/libtransact/src/execution/adapter/static_adapter.rs
@@ -313,7 +313,7 @@ mod test {
         let state = HashMapState::new();
         let state_id = HashMapState::state_id(&HashMap::new());
 
-        let (join_handle, context_manager) = ContextManagerJoinHandle::new(Box::new(state));
+        let (join_handle, mut context_manager) = ContextManagerJoinHandle::new(Box::new(state));
 
         let handler = CommandTransactionHandler::new();
 
@@ -364,7 +364,7 @@ mod test {
 
         let state = HashMapState::new();
         let state_id = HashMapState::state_id(&HashMap::new());
-        let (join_handle, context_manager) = ContextManagerJoinHandle::new(Box::new(state));
+        let (join_handle, mut context_manager) = ContextManagerJoinHandle::new(Box::new(state));
 
         let handler = CommandTransactionHandler::new();
 

--- a/libtransact/src/scheduler/mod.rs
+++ b/libtransact/src/scheduler/mod.rs
@@ -282,11 +282,11 @@ mod tests {
             &mut self,
             _dependent_contexts: &[ContextId],
             _state_id: &str,
-        ) -> ContextId {
-            [
+        ) -> Result<ContextId, ContextManagerError> {
+            Ok([
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                 0x00, 0x01,
-            ]
+            ])
         }
 
         fn get_transaction_receipt(

--- a/libtransact/src/scheduler/mod.rs
+++ b/libtransact/src/scheduler/mod.rs
@@ -297,7 +297,9 @@ mod tests {
             unimplemented!()
         }
 
-        fn drop_context(&mut self, _context_id: ContextId) {}
+        fn drop_context(&mut self, _context_id: ContextId) -> Result<(), ContextManagerError> {
+            unimplemented!()
+        }
     }
 
     pub fn test_scheduler(scheduler: &mut Scheduler) {

--- a/libtransact/src/scheduler/serial/core.rs
+++ b/libtransact/src/scheduler/serial/core.rs
@@ -234,8 +234,8 @@ impl SchedulerCore {
         let context_id = match self.previous_context {
             Some(previous_context_id) => self
                 .context_lifecycle
-                .create_context(&[previous_context_id], &self.state_id),
-            None => self.context_lifecycle.create_context(&[], &self.state_id),
+                .create_context(&[previous_context_id], &self.state_id)?,
+            None => self.context_lifecycle.create_context(&[], &self.state_id)?,
         };
 
         self.current_txn = Some(transaction_pair.transaction().header_signature().into());


### PR DESCRIPTION
Adds the implementation for the threaded Context Manager, including a ContextManagerCore which holds an internal context manager which is used based on the messages received. Also adds a ContextManagerJoinHandle which is used to start the ContextManager thread and to create ContextManagers which hold a sender to send messages to the ContextManagerCore. 

Changes the references to the thread-safe Context Manager in the sync module used in the static execution adapter to the threaded version. Also changes the ContextLifecycle trait to be used by the Context Manager thread handler so the scheduler is using the ContextManagerJoinHandle and threaded ContextManager.