### PR TITLE
Increment version to 0.1.1

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transact"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Bitwise IO, Inc."]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
Version 0.1.0 was previously released, so updating the version number
in Cargo.toml to 0.1.1.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>