### PR TITLE
Add some module documentation

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "transact"
 version = "0.1.2"
-authors = ["Bitwise IO, Inc."]
+authors = ["Bitwise IO, Inc.", "Cargill Incorporated"]
 edition = "2018"
 license = "Apache-2.0"
 readme = "../README.md"

--- a/libtransact/src/context/mod.rs
+++ b/libtransact/src/context/mod.rs
@@ -14,6 +14,12 @@
  * limitations under the License.
  * -----------------------------------------------------------------------------
  */
+//! Transaction context management.
+//!
+//! In Transact, state reads and writes are scoped (sandboxed) to a specific "context" that
+//! contains a reference to a state ID (such as a Merkle-Radix state root hash) and one or more
+//! previous contexts. The context manager implements the context lifecycle and services the calls
+//! that read, write, and delete data from state.
 
 /// Unique id that references a "Context" from which a `Transaction` can query state and
 /// modify events, data, and state.

--- a/libtransact/src/database/btree.rs
+++ b/libtransact/src/database/btree.rs
@@ -15,6 +15,13 @@
  * -----------------------------------------------------------------------------
  */
 
+//! An in-memory implementation of the database traits.
+//!
+//! This in-memory implementation of the Database uses a BTree map.  All keys are sorted by their
+//! natural order.
+//!
+//! Atomicity is provided via a RwLock.
+
 use crate::database::error::DatabaseError;
 use crate::database::{
     Database, DatabaseCursor, DatabaseReader, DatabaseReaderCursor, DatabaseWriter,

--- a/libtransact/src/database/error.rs
+++ b/libtransact/src/database/error.rs
@@ -15,6 +15,8 @@
  * ------------------------------------------------------------------------------
  */
 
+//! A common set of errors that can occur on database operations.
+
 use std;
 
 #[derive(Debug)]

--- a/libtransact/src/database/lmdb.rs
+++ b/libtransact/src/database/lmdb.rs
@@ -15,6 +15,8 @@
  * ------------------------------------------------------------------------------
  */
 
+//! An LMDB (Lightning Memory-Mapped DB) implementation of the database traits.
+
 use crate::database::{
     Database, DatabaseCursor, DatabaseReader, DatabaseReaderCursor, DatabaseWriter,
 };

--- a/libtransact/src/database/mod.rs
+++ b/libtransact/src/database/mod.rs
@@ -15,6 +15,20 @@
  * ------------------------------------------------------------------------------
  */
 
+//! Traits for reading and writing from databases.
+//!
+//! Transact operates on key-value entries at the database level, where both keys and values are
+//! opaque bytes.
+//!
+//! # Readers and Writers
+//!
+//! Both the DatabsaeReader and DatabaseWriter traits imply that the underlying database
+//! implementation maintains transactional consistency throughout their lifetimes.  For example,
+//! while a cursor on a DatabaseReader is in use, any changes to the underlying data should not
+//! alter the iteration of the reader.
+//!
+//! Changes to the underlying database are rendered via the DatabaseWriter's commit method.
+
 pub mod btree;
 pub mod error;
 pub mod lmdb;

--- a/libtransact/src/handler/mod.rs
+++ b/libtransact/src/handler/mod.rs
@@ -15,6 +15,14 @@
  * limitations under the License.
  * -----------------------------------------------------------------------------
  */
+
+//! Traits for handling the execution of a transaction.
+//!
+//! The TransactionHandler trait provides the interface for implementing smart contract engines.
+//! These handlers must be stateless and deterministic.  They are provided, along with the
+//! transaction itself, a TransactonContext implementation which provides access to reading and
+//! writing from state, as well appending events and other opaque data to the receipt.
+
 mod error;
 
 pub use crate::handler::error::{ApplyError, ContextError};

--- a/libtransact/src/lib.rs
+++ b/libtransact/src/lib.rs
@@ -1,5 +1,6 @@
 /*
  * Copyright 2018 Bitwise IO, Inc.
+ * Copyright 2019 Cargill Incorporated
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +15,104 @@
  * limitations under the License.
  * -----------------------------------------------------------------------------
  */
+
+//! # Hyperledger Transact
+//!
+//! Hyperledger Transact makes writing distributed ledger software easier by providing a shared
+//! software library that handles the execution of smart contracts, including all aspects of
+//! scheduling, transaction dispatch, and state management.
+//!
+//! Hyperledger framework-level projects and custom distributed ledgers can use Transact's
+//! advanced transaction execution and state management to simplify the transaction execution code
+//! in their projects and to take advantage of Transact’s additional features.
+//!
+//! More specifically, Transact provides an extensible approach to implementing new smart contract
+//! languages called “smart contract engines.” Each smart contract engine implements a virtual
+//! machine or interpreter that processes smart contracts. Examples include
+//! [Seth](https://sawtooth.hyperledger.org/docs/seth/nightly/master/introduction.html), which
+//! processes Ethereum Virtual Machine (EVM) smart contracts, and
+//! [Sabre](https://sawtooth.hyperledger.org/docs/sabre/nightly/master/sabre_transaction_family.html),
+//! which handles WebAssembly smart contracts. Transact also provides SDKs for implementing smart
+//! contracts and smart contract engines, which makes it easy to write smart contract business
+//! logic in a variety of programming languages.
+//!
+//! Hyperledger Transact is inspired by Hyperledger Sawtooth and uses architectural elements from
+//! Sawtooth's current transaction execution platform, including the approach to scheduling,
+//! transaction isolation, and state management. Transact is further informed by requirements from
+//! Hyperledger Fabric to support different database backends and joint experiences between
+//! Sawtooth and Fabric for flexible models for execution adapters (e.g., lessons from integrating
+//! Hyperledger Burrow).
+//!
+//! ## Diving Deeper
+//!
+//! Transact is fundamentally a transaction processing system for state transitions. State data is
+//! generally stored in a [Merkle-Radix
+//! tree](https://sawtooth.hyperledger.org/docs/core/nightly/master/glossary.html#term-merkle-radix-tree),
+//! a key-value database, or an SQL database. Given an initial state and a transaction, Transact
+//! executes the transaction to produce a new state.  These state transitions are considered “pure”
+//! because only the initial state and the transaction are used as input. (In contrast, other
+//! systems such as Ethereum combine state and block information to produce the new state.) As a
+//! result, Transact is agnostic about framework features other than transaction execution and
+//! state. Awesome, right?
+//!
+//! Transact deliberately omits other features such as consensus, blocks, chaining, and peering.
+//! These features are the responsibility of the Hyperledger frameworks (such as Sawtooth and
+//! Fabric) and other distributed ledger implementations. The focus on smart contract execution
+//! means that Transact can be used for smart contract execution without conflicting with other
+//! platform-level architectural design elements.
+//!
+//! Transact includes the following components:
+//!
+//! * State. The Transact state implementation provides get, set, and delete operations against a
+//!   database. For the Merkle-Radix tree state implementation, the tree structure is implemented on
+//!   top of LMDB or an in-memory database.
+//! * Context manager. In Transact, state reads and writes are scoped (sandboxed) to a specific
+//!   "context" that contains a reference to a state ID (such as a Merkle-Radix state root hash) and
+//!   one or more previous contexts. The context manager implements the context lifecycle and
+//!   services the calls that read, write, and delete data from state.
+//! * Scheduler. This component controls the order of transactions to be executed. Concrete
+//!   implementations include a serial scheduler and a parallel scheduler. Parallel transaction
+//!   execution is an important innovation for increasing network throughput.
+//! * Executor. The Transact executor obtains transactions from the scheduler and executes them
+//!   against a specific context. Execution is handled by sending the transaction to specific
+//!   execution adapters (such as ZMQ or a static in-process adapter) which, in turn, send the
+//!   transaction to a specific smart contract.
+//! * Smart Contract Engines. These components provide the virtual machine implementations and
+//!   interpreters that run the smart contracts. Examples of engines include WebAssembly, Ethereum
+//!   Virtual Machine, Sawtooth Transactions Processors, and Fabric Chain Code.
+//!
+//! ## Transact Features
+//!
+//! Hyperledger Transact includes the following current and upcoming features (not a complete
+//! list):
+//!
+//! * Transaction execution adapters that allow different mechanisms of execution. For example,
+//!   Transact initially provides adapters that support both in-process and external transaction
+//!   execution. The in-process adapter allows creation of a single (custom) process that can execute
+//!   specific types of transactions. The external adapter allows execution to occur in a separate
+//!   process.
+//! * Serial and parallel transaction scheduling that provides options for flexibility and
+//!   performance. Serial scheduling executes one transaction at a time, in order. Parallel
+//!   scheduling executes multiple transactions at a time, possibly out of order, with specific
+//!   constraints to guarantee a resulting state that matches the in-order execution that would occur
+//!   with serial scheduling. Parallel scheduling provides a substantial performance benefit.
+//! * Pluggable state backends with initial support for a LMDB-backed Merkle-Radix tree
+//!   implementation and an in-memory Merkle-Radix tree (primarily useful for testing). Key-value
+//!   databases and SQL databases will also be supported in the future.
+//! * Transaction receipts, which contain the resulting state changes and other information from
+//!   transaction execution.
+//! * Events that can be generated by smart contracts. These events are captured and stored in the
+//!   transaction receipt.
+//! * SDKs for the following languages: Rust, Python, Javascript, Go, Java (including Android),
+//!   Swift (iOS), C++, and .NET.
+//! * Support for multiple styles of smart contracts including Sabre (WebAssembly smart contracts)
+//!   and Seth (EVM smart contracts).
+//!
+//! ## Sawtooth Compatibility Layer
+//!
+//! Hyperledger Transact provides optional support for smart contract engines implemented for
+//! Hyperledger Sawtooth through the `sawtooth-compat` feature.
+
 #![cfg_attr(feature = "nightly", feature(test))]
 
 pub mod context;

--- a/libtransact/src/protocol/batch.rs
+++ b/libtransact/src/protocol/batch.rs
@@ -1,3 +1,26 @@
+/*
+ * Copyright 2018 Bitwise IO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+//! Batches of transactions.
+//!
+//! A Batch is a signed collection of transactions. These transactions must all succeed during
+//! execution, in order for the batch to be considered valid.  Only valid batches produce state
+//! changes.
+
 use hex;
 use protobuf::Message;
 use std;

--- a/libtransact/src/protocol/mod.rs
+++ b/libtransact/src/protocol/mod.rs
@@ -15,6 +15,11 @@
  * -----------------------------------------------------------------------------
  */
 
+//! Transact structs for batches, transactions and receipts.
+//!
+//! These structs cover the core protocols of the Transact system.  Batches of transactions are
+//! scheduled and executed.  The resuls of execution are stored in transaction receipts.
+
 pub mod batch;
 pub mod receipt;
 pub mod transaction;

--- a/libtransact/src/protocol/transaction.rs
+++ b/libtransact/src/protocol/transaction.rs
@@ -1,3 +1,25 @@
+/*
+ * Copyright 2018 Bitwise IO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+//! The fundamental transaction.
+//!
+//! A transaction is a signed, opaque payload that acts as a fundamental operation inducing a state
+//! change via a smart contract engine.  They are executed as part of a batch.
+
 use hex;
 use protobuf::Message;
 use sha2::{Digest, Sha512};

--- a/libtransact/src/protos.rs
+++ b/libtransact/src/protos.rs
@@ -15,6 +15,8 @@
  * -----------------------------------------------------------------------------
  */
 
+//! Protobuf structs and associated conversion traits.
+
 use std::error::Error as StdError;
 
 #[derive(Debug)]

--- a/libtransact/src/signing/error.rs
+++ b/libtransact/src/signing/error.rs
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2018 Bitwise IO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+//! Errors that can occur during the signing process.
+
 use std::error::Error as StdError;
 
 #[derive(Debug)]

--- a/libtransact/src/signing/hash.rs
+++ b/libtransact/src/signing/hash.rs
@@ -1,3 +1,26 @@
+/*
+ * Copyright 2018 Bitwise IO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+//! A SHA-512 Hash Signer
+//!
+//! The HashSigner provides a simple implementation of the Signer trait, by simply producing a
+//! SHA-512 hash of the message bytes.  This implementation allows for the use of transact without
+//! the need of a cryptographic library for public-private key signing.
+
 use sha2::{Digest, Sha512};
 
 use crate::signing::Error;

--- a/libtransact/src/signing/mod.rs
+++ b/libtransact/src/signing/mod.rs
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2018 Bitwise IO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+//! Simple traits for signing transactions.
+
 pub mod error;
 pub mod hash;
 


### PR DESCRIPTION
This PR adds simple documentation to all of the top level modules and some of the deeper modules.  It includes text for the library as a whole, and adds some license headers where missing.