### PR TITLE
Scheduler callback and error updates

### DIFF
--- a/libtransact/src/protocol/batch.rs
+++ b/libtransact/src/protocol/batch.rs
@@ -11,7 +11,7 @@ use crate::signing;
 
 use super::transaction::Transaction;
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct BatchHeader {
     signer_public_key: Vec<u8>,
     transaction_ids: Vec<Vec<u8>>,
@@ -83,6 +83,7 @@ impl IntoBytes for BatchHeader {
 impl IntoProto<protos::batch::BatchHeader> for BatchHeader {}
 impl IntoNative<BatchHeader> for protos::batch::BatchHeader {}
 
+#[derive(Debug, PartialEq)]
 pub struct Batch {
     header: Vec<u8>,
     header_signature: String,
@@ -117,6 +118,7 @@ impl Batch {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct BatchPair {
     batch: Batch,
     header: BatchHeader,

--- a/libtransact/src/sawtooth.rs
+++ b/libtransact/src/sawtooth.rs
@@ -273,7 +273,8 @@ mod xo_compat_test {
 
             let state_root = initial_db_root(&*db);
 
-            let mut scheduler = SerialScheduler::new(Box::new(context_manager), state_root.clone());
+            let mut scheduler = SerialScheduler::new(Box::new(context_manager), state_root.clone())
+                .expect("Failed to create scheduler");
 
             let (result_tx, result_rx) = std::sync::mpsc::channel();
             scheduler
@@ -338,7 +339,8 @@ mod xo_compat_test {
 
             let state_root = initial_db_root(&*db);
 
-            let mut scheduler = SerialScheduler::new(Box::new(context_manager), state_root.clone());
+            let mut scheduler = SerialScheduler::new(Box::new(context_manager), state_root.clone())
+                .expect("Failed to create scheduler");
 
             let (result_tx, result_rx) = std::sync::mpsc::channel();
             scheduler

--- a/libtransact/src/sawtooth.rs
+++ b/libtransact/src/sawtooth.rs
@@ -462,12 +462,15 @@ mod xo_compat_test {
     }
 
     fn run_schedule(executor: &Arc<Mutex<Option<Executor>>>, scheduler: &mut dyn Scheduler) {
+        let task_iterator = scheduler
+            .take_task_iterator()
+            .expect("Failed to take task iterator");
         executor
             .lock()
             .expect("Should not have poisoned the lock")
             .as_ref()
             .expect("Should not be None")
-            .execute(scheduler.take_task_iterator(), scheduler.new_notifier())
+            .execute(task_iterator, scheduler.new_notifier())
             .expect("Failed to execute schedule");
     }
 

--- a/libtransact/src/sawtooth.rs
+++ b/libtransact/src/sawtooth.rs
@@ -276,14 +276,18 @@ mod xo_compat_test {
             let mut scheduler = SerialScheduler::new(Box::new(context_manager), state_root.clone());
 
             let (result_tx, result_rx) = std::sync::mpsc::channel();
-            scheduler.set_result_callback(Box::new(move |batch_result| {
-                result_tx
-                    .send(batch_result)
-                    .expect("Unable to send batch result")
-            }));
+            scheduler
+                .set_result_callback(Box::new(move |batch_result| {
+                    result_tx
+                        .send(batch_result)
+                        .expect("Unable to send batch result")
+                }))
+                .expect("Failed to set result callback");
 
-            scheduler.add_batch(batch_pair);
-            scheduler.finalize();
+            scheduler
+                .add_batch(batch_pair)
+                .expect("Failed to add batch");
+            scheduler.finalize().expect("Failed to finalize scheduler");
 
             run_schedule(&test_executor, &mut scheduler);
 
@@ -337,15 +341,21 @@ mod xo_compat_test {
             let mut scheduler = SerialScheduler::new(Box::new(context_manager), state_root.clone());
 
             let (result_tx, result_rx) = std::sync::mpsc::channel();
-            scheduler.set_result_callback(Box::new(move |batch_result| {
-                result_tx
-                    .send(batch_result)
-                    .expect("Unable to send batch result")
-            }));
+            scheduler
+                .set_result_callback(Box::new(move |batch_result| {
+                    result_tx
+                        .send(batch_result)
+                        .expect("Unable to send batch result")
+                }))
+                .expect("Failed to set result callback");
 
-            scheduler.add_batch(create_batch_pair);
-            scheduler.add_batch(take_batch_pair);
-            scheduler.finalize();
+            scheduler
+                .add_batch(create_batch_pair)
+                .expect("Failed to add 1st batch");
+            scheduler
+                .add_batch(take_batch_pair)
+                .expect("Failed to add 2nd batch");
+            scheduler.finalize().expect("Failed to finalize scheduler");
 
             run_schedule(&test_executor, &mut scheduler);
 

--- a/libtransact/src/scheduler/mod.rs
+++ b/libtransact/src/scheduler/mod.rs
@@ -106,6 +106,9 @@ pub enum ExecutionTaskCompletionNotification {
 
 #[derive(Debug)]
 pub enum SchedulerError {
+    /// The scheduler's `add_batch` method was called with a batch that the scheduler already has
+    /// pending or in progress; the contained `String` is the batch ID.
+    DuplicateBatch(String),
     /// An internal error occurred that the scheduler could not recover from.
     Internal(String),
     /// The scheduler's `add_batch` method was called, but the scheduler was already finalized
@@ -118,6 +121,9 @@ pub enum SchedulerError {
 impl std::fmt::Display for SchedulerError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
+            SchedulerError::DuplicateBatch(ref batch_id) => {
+                write!(f, "duplicate batch added to scheduler: {}", batch_id)
+            }
             SchedulerError::Internal(ref err) => {
                 write!(f, "scheduler encountered an internal error: {}", err)
             }

--- a/libtransact/src/scheduler/mod.rs
+++ b/libtransact/src/scheduler/mod.rs
@@ -108,6 +108,8 @@ pub enum ExecutionTaskCompletionNotification {
 pub enum SchedulerError {
     /// An internal error occurred that the scheduler could not recover from.
     Internal(String),
+    /// The scheduler's `add_batch` method was called, but the scheduler was already finalized
+    SchedulerFinalized,
     /// An `ExecutionTaskCompletionNotification` was received for a transaction that the scheduler
     /// was not expecting; the contained `String` is the transaction ID.
     UnexpectedNotification(String),
@@ -119,6 +121,7 @@ impl std::fmt::Display for SchedulerError {
             SchedulerError::Internal(ref err) => {
                 write!(f, "scheduler encountered an internal error: {}", err)
             }
+            SchedulerError::SchedulerFinalized => write!(f, "batch added to finalized scheduler"),
             SchedulerError::UnexpectedNotification(ref txn_id) => write!(
                 f,
                 "scheduler received an unexpected notification: {}",

--- a/libtransact/src/scheduler/mod.rs
+++ b/libtransact/src/scheduler/mod.rs
@@ -105,11 +105,21 @@ pub enum ExecutionTaskCompletionNotification {
 }
 
 #[derive(Debug)]
-pub enum SchedulerError {}
+pub enum SchedulerError {
+    /// An `ExecutionTaskCompletionNotification` was received for a transaction that the scheduler
+    /// was not expecting; the contained `String` is the transaction ID.
+    UnexpectedNotification(String),
+}
 
 impl std::fmt::Display for SchedulerError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "scheduler encountered an error")
+        match *self {
+            SchedulerError::UnexpectedNotification(ref txn_id) => write!(
+                f,
+                "scheduler received an unexpected notification: {}",
+                txn_id
+            ),
+        }
     }
 }
 

--- a/libtransact/src/scheduler/mod.rs
+++ b/libtransact/src/scheduler/mod.rs
@@ -104,6 +104,15 @@ pub enum ExecutionTaskCompletionNotification {
     Valid(ContextId, String),
 }
 
+#[derive(Debug)]
+pub enum SchedulerError {}
+
+impl std::fmt::Display for SchedulerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "scheduler encountered an error")
+    }
+}
+
 /// Schedules batches and transactions and returns execution results.
 pub trait Scheduler {
     /// Sets a callback to receive results from processing batches. The order
@@ -111,6 +120,10 @@ pub trait Scheduler {
     /// batches were added with `add_batch`. If callback is called with None,
     /// all batch results have been sent.
     fn set_result_callback(&mut self, callback: Box<Fn(Option<BatchExecutionResult>) + Send>);
+
+    /// Sets a callback to receive any errors encountered by the Scheduler that are not related to
+    /// a specific batch.
+    fn set_error_callback(&mut self, callback: Box<Fn(SchedulerError) + Send>);
 
     /// Adds a BatchPair to the scheduler.
     fn add_batch(&mut self, batch: BatchPair);

--- a/libtransact/src/scheduler/mod.rs
+++ b/libtransact/src/scheduler/mod.rs
@@ -104,7 +104,7 @@ pub enum ExecutionTaskCompletionNotification {
     Valid(ContextId, String),
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum SchedulerError {
     /// The scheduler's `add_batch` method was called with a batch that the scheduler already has
     /// pending or in progress; the contained `String` is the batch ID.

--- a/libtransact/src/scheduler/serial/core.rs
+++ b/libtransact/src/scheduler/serial/core.rs
@@ -384,7 +384,7 @@ impl SchedulerCore {
                     // before this end. However, it would be more
                     // elegant to gracefully handle it by sending a
                     // close message across.
-                    error!("Thread-SerialScheduler recv error: {}", err);
+                    warn!("Thread-SerialScheduler recv failed: {}", err);
                     break;
                 }
             }

--- a/libtransact/src/scheduler/serial/core.rs
+++ b/libtransact/src/scheduler/serial/core.rs
@@ -311,17 +311,7 @@ impl SchedulerCore {
             .shared_lock
             .lock()
             .expect("scheduler shared lock is poisoned");
-        match shared.result_callback() {
-            Some(callback) => {
-                callback(Some(batch_result));
-            }
-            None => {
-                warn!(
-                    "dropped batch execution result: {}",
-                    batch_result.batch.batch().header_signature()
-                );
-            }
-        }
+        shared.result_callback()(Some(batch_result));
 
         Ok(())
     }

--- a/libtransact/src/scheduler/serial/core.rs
+++ b/libtransact/src/scheduler/serial/core.rs
@@ -389,7 +389,7 @@ impl SchedulerCore {
         Ok(())
     }
 
-    pub fn start(mut self) -> std::thread::JoinHandle<()> {
+    pub fn start(mut self) -> Result<std::thread::JoinHandle<()>, SchedulerError> {
         thread::Builder::new()
             .name(String::from("Thread-SerialScheduler"))
             .spawn(move || {
@@ -397,6 +397,11 @@ impl SchedulerCore {
                     error!("scheduler thread ended due to error: {}", err);
                 }
             })
-            .expect("could not build a thread for the scheduler")
+            .map_err(|err| {
+                SchedulerError::Internal(format!(
+                    "could not build a thread for the scheduler: {}",
+                    err
+                ))
+            })
     }
 }

--- a/libtransact/src/scheduler/serial/core.rs
+++ b/libtransact/src/scheduler/serial/core.rs
@@ -398,7 +398,14 @@ impl SchedulerCore {
             .name(String::from("Thread-SerialScheduler"))
             .spawn(move || {
                 if let Err(err) = self.run() {
-                    error!("scheduler thread ended due to error: {}", err);
+                    // Attempt to send notification using the error callback; if that fails, just
+                    // log it.
+                    let error = SchedulerError::Internal(format!(
+                        "serial scheduler's internal thread ended due to error: {}",
+                        err
+                    ));
+                    self.send_scheduler_error(error.clone())
+                        .unwrap_or_else(|_| error!("{}", error));
                 }
             })
             .map_err(|err| {

--- a/libtransact/src/scheduler/serial/execution.rs
+++ b/libtransact/src/scheduler/serial/execution.rs
@@ -80,7 +80,7 @@ impl ExecutionTaskCompletionNotifier for SerialExecutionTaskCompletionNotifier {
     fn notify(&self, notification: ExecutionTaskCompletionNotification) {
         self.tx
             .send(CoreMessage::ExecutionResult(notification))
-            .unwrap();
+            .unwrap_or_else(|err| error!("failed to send notification to core: {}", err));
     }
 
     fn clone_box(&self) -> Box<dyn ExecutionTaskCompletionNotifier> {

--- a/libtransact/src/scheduler/serial/mod.rs
+++ b/libtransact/src/scheduler/serial/mod.rs
@@ -161,13 +161,12 @@ impl Scheduler for SerialScheduler {
         Ok(())
     }
 
-    fn take_task_iterator(&mut self) -> Box<dyn Iterator<Item = ExecutionTask> + Send> {
-        match self.task_iterator.take() {
-            Some(taken) => taken,
-            None => {
-                panic!("task iterator can not be taken more than once");
-            }
-        }
+    fn take_task_iterator(
+        &mut self,
+    ) -> Result<Box<dyn Iterator<Item = ExecutionTask> + Send>, SchedulerError> {
+        self.task_iterator
+            .take()
+            .ok_or(SchedulerError::NoTaskIterator)
     }
 
     fn new_notifier(&mut self) -> Box<dyn ExecutionTaskCompletionNotifier> {

--- a/libtransact/src/scheduler/serial/mod.rs
+++ b/libtransact/src/scheduler/serial/mod.rs
@@ -121,6 +121,12 @@ impl Scheduler for SerialScheduler {
             return Err(SchedulerError::SchedulerFinalized);
         }
 
+        if shared.batch_already_queued(&batch) {
+            return Err(SchedulerError::DuplicateBatch(
+                batch.batch().header_signature().into(),
+            ));
+        }
+
         shared.add_unscheduled_batch(batch);
 
         // Notify the core that a batch has been added. Note that the batch is

--- a/libtransact/src/scheduler/serial/mod.rs
+++ b/libtransact/src/scheduler/serial/mod.rs
@@ -27,6 +27,7 @@ use crate::scheduler::BatchExecutionResult;
 use crate::scheduler::ExecutionTask;
 use crate::scheduler::ExecutionTaskCompletionNotifier;
 use crate::scheduler::Scheduler;
+use crate::scheduler::SchedulerError;
 
 use std::sync::mpsc;
 use std::sync::mpsc::Sender;
@@ -94,6 +95,14 @@ impl Scheduler for SerialScheduler {
             .lock()
             .expect("scheduler shared lock is poisoned");
         shared.set_result_callback(callback);
+    }
+
+    fn set_error_callback(&mut self, callback: Box<Fn(SchedulerError) + Send>) {
+        let mut shared = self
+            .shared_lock
+            .lock()
+            .expect("scheduler shared lock is poisoned");
+        shared.set_error_callback(callback);
     }
 
     fn add_batch(&mut self, batch: BatchPair) {

--- a/libtransact/src/scheduler/serial/mod.rs
+++ b/libtransact/src/scheduler/serial/mod.rs
@@ -105,10 +105,7 @@ impl SerialScheduler {
                 }
             }
             Err(err) => {
-                error!(
-                    "failed to send to send to scheduler thread during drop: {}",
-                    err
-                );
+                warn!("failed to send to scheduler thread during drop: {}", err);
             }
         }
     }

--- a/libtransact/src/scheduler/serial/mod.rs
+++ b/libtransact/src/scheduler/serial/mod.rs
@@ -92,7 +92,13 @@ impl SerialScheduler {
         match self.core_tx.send(core::CoreMessage::Shutdown) {
             Ok(_) => {
                 if let Some(join_handle) = self.core_handle.take() {
-                    join_handle.join().expect("failed to join scheduler thread");
+                    join_handle.join().unwrap_or_else(|err| {
+                        // This should not never happen, because the core thread should never panic
+                        error!(
+                            "failed to join scheduler thread because it panicked: {:?}",
+                            err
+                        )
+                    });
                 }
             }
             Err(err) => {

--- a/libtransact/src/scheduler/serial/mod.rs
+++ b/libtransact/src/scheduler/serial/mod.rs
@@ -118,7 +118,7 @@ impl Scheduler for SerialScheduler {
         let mut shared = self.shared_lock.lock()?;
 
         if shared.finalized() {
-            panic!("add_batch called after scheduler finalized");
+            return Err(SchedulerError::SchedulerFinalized);
         }
 
         shared.add_unscheduled_batch(batch);

--- a/libtransact/src/scheduler/serial/shared.rs
+++ b/libtransact/src/scheduler/serial/shared.rs
@@ -65,6 +65,10 @@ impl Shared {
         self.error_callback = callback;
     }
 
+    pub fn batch_already_queued(&self, batch: &BatchPair) -> bool {
+        self.unscheduled_batches.contains(batch)
+    }
+
     pub fn add_unscheduled_batch(&mut self, batch: BatchPair) {
         self.unscheduled_batches.push_back(batch);
     }

--- a/libtransact/src/scheduler/serial/shared.rs
+++ b/libtransact/src/scheduler/serial/shared.rs
@@ -31,6 +31,12 @@ pub struct Shared {
     unscheduled_batches: VecDeque<BatchPair>,
 }
 
+impl Default for Shared {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Shared {
     pub fn new() -> Self {
         Shared {


### PR DESCRIPTION
- Improves how the serial scheudler's result callback is used
- Adds an error callback to the Scheduler trait that's used to report errors to the calling code
- Updates the serial scheduler to not panic; instead, it will propagate errors up where appropriate or simply log them