### PR TITLE
Serial scheduler done

### DIFF
--- a/libtransact/src/scheduler/mod.rs
+++ b/libtransact/src/scheduler/mod.rs
@@ -146,7 +146,8 @@ pub trait Scheduler {
     /// Sets a callback to receive results from processing batches. The order
     /// the results are received is not guarenteed to be the same order as the
     /// batches were added with `add_batch`. If callback is called with None,
-    /// all batch results have been sent.
+    /// all batch results have been sent (only used when the scheduler has been
+    /// finalized and no more batches will be added).
     fn set_result_callback(
         &mut self,
         callback: Box<Fn(Option<BatchExecutionResult>) + Send>,

--- a/libtransact/src/scheduler/serial/mod.rs
+++ b/libtransact/src/scheduler/serial/mod.rs
@@ -158,6 +158,7 @@ impl Scheduler for SerialScheduler {
 
     fn finalize(&mut self) -> Result<(), SchedulerError> {
         self.shared_lock.lock()?.set_finalized(true);
+        self.core_tx.send(core::CoreMessage::Finalized)?;
         Ok(())
     }
 

--- a/libtransact/src/scheduler/serial/shared.rs
+++ b/libtransact/src/scheduler/serial/shared.rs
@@ -75,6 +75,10 @@ impl Shared {
         self.unscheduled_batches.contains(batch)
     }
 
+    pub fn unscheduled_batches_is_empty(&self) -> bool {
+        self.unscheduled_batches.is_empty()
+    }
+
     pub fn add_unscheduled_batch(&mut self, batch: BatchPair) {
         self.unscheduled_batches.push_back(batch);
     }


### PR DESCRIPTION
Updates the serial scheduler to return a None result when it is
finalized and all batches have been executed. This is triggered in two
ways:

1. When the scheduler is finalized, a notification is sent to the serial
scheduler's core thread; if there are no unscheduled batches and no
batch currently executing, the None result is sent.
2. If there are unscheduled batches or a batch is currently executing
when the scheduler is finalized, the scheduler will wait until all
batches have been executed, then send the None result.

Signed-off-by: Logan Seeley <seeley@bitwise.io>